### PR TITLE
Refactor: rename `PermissionRepository` to  `PolicyRepository`

### DIFF
--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/policy/Statement.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/policy/Statement.kt
@@ -24,16 +24,16 @@ interface Statement : PermissionVerifier {
     override fun verify(request: Request, securityContext: SecurityContext): VerifyResult {
         conditions.all {
             it.match(request, securityContext)
-        }.let { conditionMatched ->
-            if (!conditionMatched) {
+        }.let { allMatched ->
+            if (!allMatched) {
                 return VerifyResult.IMPLICIT_DENY
             }
         }
 
         actions.any {
             it.match(request, securityContext)
-        }.let { actionMatched ->
-            if (!actionMatched) {
+        }.let { anyMatched ->
+            if (!anyMatched) {
                 return VerifyResult.IMPLICIT_DENY
             }
         }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/PolicyRepository.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/PolicyRepository.kt
@@ -17,13 +17,12 @@ import me.ahoo.cosec.api.policy.Policy
 import reactor.core.publisher.Mono
 
 /**
- * TODO rename? PolicyRepository?
  *
- * Permission Repository .
+ * Policy Repository .
  *
  * @author ahoo wang
  */
-interface PermissionRepository {
+interface PolicyRepository {
     fun getGlobalPolicy(): Mono<Set<Policy>>
     fun getRolePolicy(roleIds: Set<String>): Mono<Set<Policy>>
     fun getPolicies(policyIds: Set<String>): Mono<Set<Policy>>

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
@@ -29,7 +29,7 @@ import reactor.kotlin.core.publisher.toMono
  *
  * @author ahoo wang
  */
-class SimpleAuthorization(private val permissionRepository: PermissionRepository) : Authorization {
+class SimpleAuthorization(private val policyRepository: PolicyRepository) : Authorization {
 
     private fun verifyPolicies(policies: Set<Policy>, request: Request, context: SecurityContext): VerifyResult {
         policies.forEach { policy: Policy ->
@@ -66,7 +66,7 @@ class SimpleAuthorization(private val permissionRepository: PermissionRepository
     }
 
     private fun verifyGlobalPolicies(request: Request, context: SecurityContext): Mono<VerifyResult> {
-        return permissionRepository.getGlobalPolicy()
+        return policyRepository.getGlobalPolicy()
             .defaultIfEmpty(emptySet())
             .map { policies: Set<Policy> ->
                 verifyPolicies(policies, request, context)
@@ -77,7 +77,7 @@ class SimpleAuthorization(private val permissionRepository: PermissionRepository
         if (context.principal.policies.isEmpty()) {
             return VerifyResult.IMPLICIT_DENY.toMono()
         }
-        return permissionRepository.getPolicies(context.principal.policies)
+        return policyRepository.getPolicies(context.principal.policies)
             .defaultIfEmpty(emptySet())
             .map { policies: Set<Policy> ->
                 verifyPolicies(policies, request, context)
@@ -88,7 +88,7 @@ class SimpleAuthorization(private val permissionRepository: PermissionRepository
         if (context.principal.roles.isEmpty()) {
             return VerifyResult.IMPLICIT_DENY.toMono()
         }
-        return permissionRepository.getRolePolicy(context.principal.roles)
+        return policyRepository.getRolePolicy(context.principal.roles)
             .defaultIfEmpty(emptySet())
             .map { policies: Set<Policy> ->
                 verifyPolicies(policies, request, context)

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/authorization/SimpleAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/authorization/SimpleAuthorizationTest.kt
@@ -32,8 +32,8 @@ import reactor.kotlin.test.test
 internal class SimpleAuthorizationTest {
     @Test
     fun authorizeWhenPrincipalIsRoot() {
-        val permissionRepository = mockk<PermissionRepository>()
-        val authorization = SimpleAuthorization(permissionRepository)
+        val policyRepository = mockk<PolicyRepository>()
+        val authorization = SimpleAuthorization(policyRepository)
         val request = mockk<Request>()
         val securityContext = mockk<SecurityContext> {
             every { principal.id } returns CoSecPrincipal.ROOT_ID
@@ -46,12 +46,12 @@ internal class SimpleAuthorizationTest {
 
     @Test
     fun authorizeWhenPolicyIsEmpty() {
-        val permissionRepository = mockk<PermissionRepository>() {
+        val policyRepository = mockk<PolicyRepository>() {
             every { getGlobalPolicy() } returns Mono.empty()
             every { getRolePolicy(any()) } returns Mono.empty()
             every { getPolicies(any()) } returns Mono.empty()
         }
-        val authorization = SimpleAuthorization(permissionRepository)
+        val authorization = SimpleAuthorization(policyRepository)
         val request = mockk<Request> {
         }
 
@@ -71,12 +71,12 @@ internal class SimpleAuthorizationTest {
                 )
             )
         }
-        val permissionRepository = mockk<PermissionRepository>() {
+        val policyRepository = mockk<PolicyRepository>() {
             every { getGlobalPolicy() } returns Mono.just(setOf(globalPolicy))
             every { getRolePolicy(any()) } returns Mono.empty()
             every { getPolicies(any()) } returns Mono.empty()
         }
-        val authorization = SimpleAuthorization(permissionRepository)
+        val authorization = SimpleAuthorization(policyRepository)
         val request = mockk<Request> {
         }
 
@@ -96,12 +96,12 @@ internal class SimpleAuthorizationTest {
                 )
             )
         }
-        val permissionRepository = mockk<PermissionRepository>() {
+        val policyRepository = mockk<PolicyRepository>() {
             every { getGlobalPolicy() } returns Mono.just(setOf(globalPolicy))
             every { getRolePolicy(any()) } returns Mono.empty()
             every { getPolicies(any()) } returns Mono.empty()
         }
-        val authorization = SimpleAuthorization(permissionRepository)
+        val authorization = SimpleAuthorization(policyRepository)
         val request = mockk<Request>()
 
         authorization.authorize(request, SimpleSecurityContext.ANONYMOUS)
@@ -125,12 +125,12 @@ internal class SimpleAuthorizationTest {
             every { principal.id } returns ""
             every { principal.policies } returns setOf("principalPolicy")
         }
-        val permissionRepository = mockk<PermissionRepository>() {
+        val policyRepository = mockk<PolicyRepository>() {
             every { getGlobalPolicy() } returns Mono.empty()
             every { getPolicies(any()) } returns Mono.just(setOf(principalPolicy))
             every { getRolePolicy(any()) } returns Mono.empty()
         }
-        val authorization = SimpleAuthorization(permissionRepository)
+        val authorization = SimpleAuthorization(policyRepository)
         val request = mockk<Request> {
         }
 
@@ -155,12 +155,12 @@ internal class SimpleAuthorizationTest {
             every { principal.id } returns ""
             every { principal.policies } returns setOf("principalPolicy")
         }
-        val permissionRepository = mockk<PermissionRepository>() {
+        val policyRepository = mockk<PolicyRepository>() {
             every { getGlobalPolicy() } returns Mono.empty()
             every { getPolicies(any()) } returns Mono.just(setOf(principalPolicy))
             every { getRolePolicy(any()) } returns Mono.empty()
         }
-        val authorization = SimpleAuthorization(permissionRepository)
+        val authorization = SimpleAuthorization(policyRepository)
         val request = mockk<Request> {
         }
 
@@ -186,12 +186,12 @@ internal class SimpleAuthorizationTest {
             every { principal.policies } returns emptySet()
             every { principal.roles } returns setOf("rolePolicy")
         }
-        val permissionRepository = mockk<PermissionRepository>() {
+        val policyRepository = mockk<PolicyRepository>() {
             every { getGlobalPolicy() } returns Mono.empty()
             every { getPolicies(any()) } returns Mono.empty()
             every { getRolePolicy(any()) } returns Mono.just(setOf(rolePolicy))
         }
-        val authorization = SimpleAuthorization(permissionRepository)
+        val authorization = SimpleAuthorization(policyRepository)
         val request = mockk<Request> {
         }
 
@@ -217,12 +217,12 @@ internal class SimpleAuthorizationTest {
             every { principal.policies } returns emptySet()
             every { principal.roles } returns setOf("rolePolicy")
         }
-        val permissionRepository = mockk<PermissionRepository>() {
+        val policyRepository = mockk<PolicyRepository>() {
             every { getGlobalPolicy() } returns Mono.empty()
             every { getPolicies(any()) } returns Mono.empty()
             every { getRolePolicy(any()) } returns Mono.just(setOf(rolePolicy))
         }
-        val authorization = SimpleAuthorization(permissionRepository)
+        val authorization = SimpleAuthorization(policyRepository)
         val request = mockk<Request> {
         }
 

--- a/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/RedisPolicyRepository.kt
+++ b/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/RedisPolicyRepository.kt
@@ -14,15 +14,15 @@
 package me.ahoo.cosec.redis
 
 import me.ahoo.cosec.api.policy.Policy
-import me.ahoo.cosec.authorization.PermissionRepository
+import me.ahoo.cosec.authorization.PolicyRepository
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
-class RedisPermissionRepository(
+class RedisPolicyRepository(
     private val globalPolicyIndexCache: GlobalPolicyIndexCache,
     private val rolePolicyCache: RolePolicyCache,
     private val policyCache: PolicyCache
-) : PermissionRepository {
+) : PolicyRepository {
     override fun getGlobalPolicy(): Mono<Set<Policy>> {
         return globalPolicyIndexCache[GlobalPolicyIndexKey]
             .orEmpty()

--- a/cosec-redis/src/test/kotlin/me/ahoo/cosec/redis/RedisPolicyRepositoryTest.kt
+++ b/cosec-redis/src/test/kotlin/me/ahoo/cosec/redis/RedisPolicyRepositoryTest.kt
@@ -20,7 +20,7 @@ import me.ahoo.cosec.policy.PolicyData
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
-internal class RedisPermissionRepositoryTest {
+internal class RedisPolicyRepositoryTest {
 
     private val policyData = PolicyData(
         "policyId",
@@ -36,7 +36,7 @@ internal class RedisPermissionRepositoryTest {
     fun getGlobalPolicyWhenIsEmpty() {
         val globalPolicyIndexCache = mockk<GlobalPolicyIndexCache>()
         every { globalPolicyIndexCache.get(GlobalPolicyIndexKey) } returns emptySet()
-        val permissionRepository = RedisPermissionRepository(globalPolicyIndexCache, mockk(), mockPolicyCache())
+        val permissionRepository = RedisPolicyRepository(globalPolicyIndexCache, mockk(), mockPolicyCache())
         permissionRepository.getGlobalPolicy()
             .test()
             .expectNext(emptySet())
@@ -47,7 +47,7 @@ internal class RedisPermissionRepositoryTest {
     fun getGlobalPolicy() {
         val globalPolicyIndexCache = mockk<GlobalPolicyIndexCache>()
         every { globalPolicyIndexCache.get(GlobalPolicyIndexKey) } returns setOf("policyId")
-        val permissionRepository = RedisPermissionRepository(globalPolicyIndexCache, mockk(), mockPolicyCache())
+        val permissionRepository = RedisPolicyRepository(globalPolicyIndexCache, mockk(), mockPolicyCache())
         permissionRepository.getGlobalPolicy()
             .test()
             .expectNext(setOf(policyData))
@@ -58,7 +58,7 @@ internal class RedisPermissionRepositoryTest {
     fun getRolePolicyWhenIsEmpty() {
         val rolePolicyCache = mockk<RolePolicyCache>()
         every { rolePolicyCache.get("roleId") } returns emptySet()
-        val permissionRepository = RedisPermissionRepository(mockk(), rolePolicyCache, mockPolicyCache())
+        val permissionRepository = RedisPolicyRepository(mockk(), rolePolicyCache, mockPolicyCache())
         permissionRepository.getRolePolicy(setOf("roleId"))
             .test()
             .expectNext(emptySet())
@@ -69,7 +69,7 @@ internal class RedisPermissionRepositoryTest {
     fun getRolePolicy() {
         val rolePolicyCache = mockk<RolePolicyCache>()
         every { rolePolicyCache.get("roleId") } returns setOf("policyId")
-        val permissionRepository = RedisPermissionRepository(mockk(), rolePolicyCache, mockPolicyCache())
+        val permissionRepository = RedisPolicyRepository(mockk(), rolePolicyCache, mockPolicyCache())
         permissionRepository.getRolePolicy(setOf("roleId"))
             .test()
             .expectNext(setOf(policyData))
@@ -78,7 +78,7 @@ internal class RedisPermissionRepositoryTest {
 
     @Test
     fun getPoliciesWhenPolicyIsEmpty() {
-        val permissionRepository = RedisPermissionRepository(mockk(), mockk(), mockk())
+        val permissionRepository = RedisPolicyRepository(mockk(), mockk(), mockk())
         permissionRepository.getPolicies(emptySet())
             .test()
             .expectNext(emptySet())
@@ -87,7 +87,7 @@ internal class RedisPermissionRepositoryTest {
 
     @Test
     fun getPolicies() {
-        val permissionRepository = RedisPermissionRepository(mockk(), mockk(), mockPolicyCache())
+        val permissionRepository = RedisPolicyRepository(mockk(), mockk(), mockPolicyCache())
         permissionRepository.getPolicies(setOf("policyId"))
             .test()
             .expectNext(setOf(policyData))

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecAuthorizationAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecAuthorizationAutoConfiguration.kt
@@ -13,7 +13,7 @@
 package me.ahoo.cosec.spring.boot.starter.authorization
 
 import me.ahoo.cosec.api.authorization.Authorization
-import me.ahoo.cosec.authorization.PermissionRepository
+import me.ahoo.cosec.authorization.PolicyRepository
 import me.ahoo.cosec.authorization.SimpleAuthorization
 import me.ahoo.cosec.context.SecurityContextParser
 import me.ahoo.cosec.context.request.RemoteIpResolver
@@ -55,9 +55,9 @@ class CoSecAuthorizationAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     fun cosecAuthorization(
-        permissionRepository: PermissionRepository
+        policyRepository: PolicyRepository
     ): Authorization {
-        return SimpleAuthorization(permissionRepository)
+        return SimpleAuthorization(policyRepository)
     }
 
     companion object {

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecCacheAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecCacheAutoConfiguration.kt
@@ -23,11 +23,11 @@ import me.ahoo.cache.spring.redis.RedisDistributedCache
 import me.ahoo.cache.spring.redis.codec.ObjectToJsonCodecExecutor
 import me.ahoo.cache.spring.redis.codec.SetToSetCodecExecutor
 import me.ahoo.cosec.api.policy.Policy
-import me.ahoo.cosec.authorization.PermissionRepository
+import me.ahoo.cosec.authorization.PolicyRepository
 import me.ahoo.cosec.redis.GlobalPolicyIndexCache
 import me.ahoo.cosec.redis.GlobalPolicyIndexKey
 import me.ahoo.cosec.redis.PolicyCache
-import me.ahoo.cosec.redis.RedisPermissionRepository
+import me.ahoo.cosec.redis.RedisPolicyRepository
 import me.ahoo.cosec.redis.RolePolicyCache
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
@@ -65,12 +65,12 @@ class CoSecCacheAutoConfiguration(private val cacheProperties: CacheProperties) 
 
     @Bean
     @ConditionalOnMissingBean
-    fun redisPermissionRepository(
+    fun redisPolicyRepository(
         globalPolicyIndexCache: GlobalPolicyIndexCache,
         rolePolicyCache: RolePolicyCache,
         policyCache: PolicyCache
-    ): PermissionRepository {
-        return RedisPermissionRepository(
+    ): PolicyRepository {
+        return RedisPolicyRepository(
             globalPolicyIndexCache,
             rolePolicyCache,
             policyCache

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecCacheAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecCacheAutoConfigurationTest.kt
@@ -14,7 +14,7 @@
 package me.ahoo.cosec.spring.boot.starter.authorization.cache
 
 import me.ahoo.cache.spring.boot.starter.CoCacheAutoConfiguration
-import me.ahoo.cosec.authorization.PermissionRepository
+import me.ahoo.cosec.authorization.PolicyRepository
 import me.ahoo.cosec.redis.GlobalPolicyIndexCache
 import me.ahoo.cosec.redis.PolicyCache
 import me.ahoo.cosec.redis.RolePolicyCache
@@ -48,7 +48,7 @@ internal class CoSecCacheAutoConfigurationTest {
                     .hasSingleBean(RolePolicyCache::class.java)
                     .hasBean(CoSecCacheAutoConfiguration.POLICY_CACHE_SOURCE_BEAN_NAME)
                     .hasSingleBean(PolicyCache::class.java)
-                    .hasSingleBean(PermissionRepository::class.java)
+                    .hasSingleBean(PolicyRepository::class.java)
             }
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
- Refactor: rename `PermissionRepository` to  `PolicyRepository`

