### PR TITLE
Refactor: remove dependency `org.junit-pioneer:junit-pioneer`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,7 +142,6 @@ configure(libraryProjects) {
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")
-        testImplementation("org.junit-pioneer:junit-pioneer")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
         detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
         jmh("org.openjdk.jmh:jmh-core")

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/principal/CoSecPrincipalTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/principal/CoSecPrincipalTest.kt
@@ -13,10 +13,10 @@
 package me.ahoo.cosec.principal
 
 import me.ahoo.cosec.api.principal.CoSecPrincipal
-import org.junit.jupiter.api.Assertions
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.junitpioneer.jupiter.SetSystemProperty
 
 /**
  * CoSecPrincipalTest .
@@ -25,9 +25,10 @@ import org.junitpioneer.jupiter.SetSystemProperty
  */
 internal class CoSecPrincipalTest {
     @Disabled
-    @SetSystemProperty(key = CoSecPrincipal.ROOT_KEY, value = "root")
     @Test
     fun rootWhenSetSystemProperty() {
-        Assertions.assertEquals("root", CoSecPrincipal.ROOT_ID)
+        System.setProperty(CoSecPrincipal.ROOT_KEY, "root")
+        assertThat(CoSecPrincipal.ROOT_ID, equalTo("root"))
+        System.clearProperty(CoSecPrincipal.ROOT_KEY)
     }
 }

--- a/cosec-dependencies/build.gradle.kts
+++ b/cosec-dependencies/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
         api("org.lionsoul:ip2region:2.6.6")
         api("com.google.guava:guava:31.1-jre")
         api("io.opentelemetry:opentelemetry-semconv:1.20.1-alpha")
-        api("org.junit-pioneer:junit-pioneer:1.9.1")
         api("org.hamcrest:hamcrest:2.2")
         api("io.mockk:mockk:1.13.4")
         api("org.openjdk.jmh:jmh-core:1.36")

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosec
-version=1.10.6
+version=1.10.8
 description=RBAC-based And Policy-based Multi-Tenant Reactive Security Framework
 website=https://github.com/Ahoo-Wang/CoSec
 issues=https://github.com/Ahoo-Wang/CoSec/issues


### PR DESCRIPTION


Changes proposed in this pull request:
- Refactor: remove dependency `org.junit-pioneer:junit-pioneer`

