### PR TITLE
refactor: support `AuthorizeResult.TOKEN_EXPIRED`

### DIFF
--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/authorization/AuthorizeResult.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/authorization/AuthorizeResult.kt
@@ -18,9 +18,14 @@ interface AuthorizeResult {
     val reason: String
 
     companion object {
-        val ALLOW: AuthorizeResult = allow("Allow")
-        val EXPLICIT_DENY: AuthorizeResult = deny("Explicit Deny")
-        val IMPLICIT_DENY: AuthorizeResult = deny("Implicit Deny")
+        private const val ALLOW_REASON = "Allow"
+        private const val EXPLICIT_DENY_REASON = "Explicit Deny"
+        private const val IMPLICIT_DENY_REASON = "Implicit Deny"
+        private const val ACCESS_TOKEN_EXPIRED_REASON = "Access Token Expired"
+        val ALLOW: AuthorizeResult = allow(ALLOW_REASON)
+        val EXPLICIT_DENY: AuthorizeResult = deny(EXPLICIT_DENY_REASON)
+        val IMPLICIT_DENY: AuthorizeResult = deny(IMPLICIT_DENY_REASON)
+        val TOKEN_EXPIRED: AuthorizeResult = deny(ACCESS_TOKEN_EXPIRED_REASON)
         fun allow(reason: String): AuthorizeResult = AuthorizeResultData(true, reason)
         fun deny(reason: String): AuthorizeResult = AuthorizeResultData(false, reason)
     }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/SecurityContextParser.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/SecurityContextParser.kt
@@ -13,7 +13,9 @@
 package me.ahoo.cosec.context
 
 import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.token.TokenExpiredException
 import org.slf4j.LoggerFactory
+import kotlin.jvm.Throws
 
 /**
  * Security Context Parser .
@@ -23,6 +25,7 @@ import org.slf4j.LoggerFactory
 private val LOG = LoggerFactory.getLogger(SecurityContextParser::class.java)
 
 fun interface SecurityContextParser<R> {
+    @Throws(TokenExpiredException::class)
     fun parse(request: R): SecurityContext
 
     fun ensureParse(request: R): SecurityContext {

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
@@ -14,11 +14,12 @@
 package me.ahoo.cosec.servlet
 
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.context.SecurityContextHolder
-import me.ahoo.cosec.context.SimpleSecurityContext
 import me.ahoo.cosec.jwt.Jwts
 import me.ahoo.cosec.principal.SimpleTenantPrincipal
 import me.ahoo.cosec.servlet.ServletRequests.setSecurityContext
@@ -27,6 +28,7 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import reactor.kotlin.core.publisher.toMono
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
@@ -80,6 +82,7 @@ internal class AuthorizationFilterTest {
             every { setSecurityContext(any()) } returns Unit
         }
         val servletResponse = mockk<HttpServletResponse> {
+            every { contentType = MediaType.APPLICATION_JSON_VALUE } just runs
             every { status = HttpStatus.UNAUTHORIZED.value() } returns Unit
             every { outputStream.write(any() as ByteArray) } returns Unit
             every { outputStream.flush() } returns Unit

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosec
-version=1.12.0
+version=1.12.1
 description=RBAC-based And Policy-based Multi-Tenant Reactive Security Framework
 website=https://github.com/Ahoo-Wang/CoSec
 issues=https://github.com/Ahoo-Wang/CoSec/issues


### PR DESCRIPTION


Changes proposed in this pull request:
- refactor: support `AuthorizeResult.TOKEN_EXPIRED`

