### PR TITLE
feat: add `CompositeActionMatcher`

### DIFF
--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/CompositeActionMatcher.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/CompositeActionMatcher.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.policy.action
+
+import me.ahoo.cosec.api.configuration.Configuration
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.api.policy.ActionMatcher
+
+class CompositeActionMatcher(
+    override val type: String,
+    private val actionMatchers: List<ActionMatcher>,
+    override val configuration: Configuration
+) : ActionMatcher {
+
+    override fun match(request: Request, securityContext: SecurityContext): Boolean {
+        return actionMatchers.any { pathActionMatcher ->
+            pathActionMatcher.match(request, securityContext)
+        }
+    }
+}
+
+class CompositeActionMatcherFactory : ActionMatcherFactory {
+    companion object {
+        const val TYPE = "composite"
+    }
+
+    override val type: String
+        get() = TYPE
+
+    override fun create(configuration: Configuration): ActionMatcher {
+        configuration.asList().let { actionMatcherConfigurations ->
+            val actionMatchers = actionMatcherConfigurations.map { actionMatcherConfiguration ->
+                actionMatcherConfiguration.asObject(ActionMatcher::class.java)
+            }
+            return CompositeActionMatcher(TYPE, actionMatchers, configuration)
+        }
+    }
+}

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/PathActionMatcher.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/PathActionMatcher.kt
@@ -52,20 +52,6 @@ class ReplaceablePathActionMatcher(
     }
 }
 
-class CompositePathActionMatcher(
-    private val actionMatchers: List<ActionMatcher>,
-    override val configuration: Configuration
-) : ActionMatcher {
-    override val type: String
-        get() = PathActionMatcherFactory.TYPE
-
-    override fun match(request: Request, securityContext: SecurityContext): Boolean {
-        return actionMatchers.any { pathActionMatcher ->
-            pathActionMatcher.match(request, securityContext)
-        }
-    }
-}
-
 class PathActionMatcherFactory : ActionMatcherFactory {
     companion object {
         const val TYPE = "path"
@@ -99,7 +85,8 @@ class PathActionMatcherFactory : ActionMatcherFactory {
             asList()
                 .map { it.stringAsActionMatcher() }
                 .let { actionMatchers ->
-                    return CompositePathActionMatcher(
+                    return CompositeActionMatcher(
+                        type = TYPE,
                         actionMatchers = actionMatchers,
                         configuration = this
                     )
@@ -118,7 +105,8 @@ class PathActionMatcherFactory : ActionMatcherFactory {
                     if (actionMatchers.size == 1) {
                         return actionMatchers.first()
                     }
-                    return CompositePathActionMatcher(
+                    return CompositeActionMatcher(
+                        type = TYPE,
                         actionMatchers = actionMatchers,
                         configuration = this
                     )

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/serialization/JsonActionMatcherSerializer.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/serialization/JsonActionMatcherSerializer.kt
@@ -28,7 +28,9 @@ import me.ahoo.cosec.policy.action.PathActionMatcherFactory
 
 object JsonActionMatcherSerializer : StdSerializer<ActionMatcher>(ActionMatcher::class.java) {
     override fun serialize(value: ActionMatcher, gen: JsonGenerator, provider: SerializerProvider) {
-        if (value.configuration.isString || value.configuration.isArray) {
+        if (value.type == PathActionMatcherFactory.TYPE &&
+            (value.configuration.isString || value.configuration.isArray)
+        ) {
             gen.writePOJO(value.configuration)
             return
         }

--- a/cosec-core/src/main/resources/META-INF/services/me.ahoo.cosec.policy.action.ActionMatcherFactory
+++ b/cosec-core/src/main/resources/META-INF/services/me.ahoo.cosec.policy.action.ActionMatcherFactory
@@ -12,3 +12,4 @@
 #
 me.ahoo.cosec.policy.action.AllActionMatcherFactory
 me.ahoo.cosec.policy.action.PathActionMatcherFactory
+me.ahoo.cosec.policy.action.CompositeActionMatcherFactory

--- a/cosec-core/src/test/resources/test-policy.json
+++ b/cosec-core/src/test/resources/test-policy.json
@@ -206,6 +206,23 @@
           }
         }
       }
+    },
+    {
+      "name": "TestComposite",
+      "effect": "allow",
+      "action": {
+        "composite": [
+          "/user/#{principal.id}/*",
+          {
+            "path": {
+              "method": "POST",
+              "pattern": [
+                "/user/#{principal.id}/order/*"
+              ]
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosec
-version=1.16.5
+version=1.16.6
 description=RBAC-based And Policy-based Multi-Tenant Reactive Security Framework
 website=https://github.com/Ahoo-Wang/CoSec
 issues=https://github.com/Ahoo-Wang/CoSec/issues

--- a/schema/action.schema.json
+++ b/schema/action.schema.json
@@ -18,6 +18,9 @@
         "path": {
           "$ref": "#/definitions/pathActionMatcher"
         },
+        "composite": {
+          "$ref": "#/definitions/compositeActionMatcher"
+        },
         "all": {
           "$ref": "#/definitions/allActionMatcher"
         }
@@ -84,6 +87,25 @@
       "required": [
         "pattern"
       ]
+    },
+    "compositeActionMatcher": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "path": {
+                "$ref": "#/definitions/pathActionMatcher"
+              }
+            }
+          }
+        ]
+      },
+      "minItems": 1
     }
   }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
- feat: add `CompositeActionMatcher`

```json 
    {
      "name": "TestComposite",
      "effect": "allow",
      "action": {
        "composite": [
          "/user/#{principal.id}/*",
          {
            "path": {
              "method": "POST",
              "pattern": [
                "/user/#{principal.id}/order/*"
              ]
            }
          }
        ]
      }
    }
```
