### PR TITLE
feat: add `InRoleConditionMatcher`

### DIFF
--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/context/InRoleConditionMatcher.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/context/InRoleConditionMatcher.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.policy.condition.context
+
+import me.ahoo.cosec.api.configuration.Configuration
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.api.policy.ConditionMatcher
+import me.ahoo.cosec.policy.condition.AbstractConditionMatcher
+import me.ahoo.cosec.policy.condition.ConditionMatcherFactory
+
+class InRoleConditionMatcher(configuration: Configuration) :
+    AbstractConditionMatcher(InRoleConditionMatcherFactory.TYPE, configuration) {
+    private val value: String = configuration.getRequired(InRoleConditionMatcher::value.name).asString()
+
+    override fun internalMatch(request: Request, securityContext: SecurityContext): Boolean {
+        return securityContext.principal.roles.contains(value)
+    }
+}
+
+class InRoleConditionMatcherFactory : ConditionMatcherFactory {
+    companion object {
+        const val TYPE = "inRole"
+    }
+
+    override val type: String
+        get() = TYPE
+
+    override fun create(configuration: Configuration): ConditionMatcher {
+        return InRoleConditionMatcher(configuration)
+    }
+}

--- a/cosec-core/src/main/resources/META-INF/services/me.ahoo.cosec.policy.condition.ConditionMatcherFactory
+++ b/cosec-core/src/main/resources/META-INF/services/me.ahoo.cosec.policy.condition.ConditionMatcherFactory
@@ -14,6 +14,7 @@
 me.ahoo.cosec.policy.condition.AllConditionMatcherFactory
 me.ahoo.cosec.policy.condition.context.AuthenticatedConditionMatcherFactory
 me.ahoo.cosec.policy.condition.context.InTenantConditionMatcherFactory
+me.ahoo.cosec.policy.condition.context.InRoleConditionMatcherFactory
 me.ahoo.cosec.policy.condition.part.ContainsConditionMatcherFactory
 me.ahoo.cosec.policy.condition.part.InConditionMatcherFactory
 me.ahoo.cosec.policy.condition.part.EqConditionMatcherFactory

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/condition/context/InRoleConditionMatcherTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/condition/context/InRoleConditionMatcherTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.policy.condition.context
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.configuration.JsonConfiguration.Companion.asConfiguration
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.notNullValue
+
+import org.junit.jupiter.api.Test
+
+class InRoleConditionMatcherTest {
+    @Test
+    fun match() {
+        val request: Request = mockk()
+        val context: SecurityContext = mockk {
+            every { principal.roles } returns setOf("roleId")
+        }
+        val conditionMatcher = InRoleConditionMatcherFactory()
+            .create(
+                mapOf(
+                    "value" to "roleId",
+                ).asConfiguration(),
+            )
+        assertThat(conditionMatcher.type, `is`(InRoleConditionMatcherFactory.TYPE))
+        assertThat(conditionMatcher.configuration, notNullValue())
+        assertThat(conditionMatcher.match(request, context), `is`(true))
+    }
+}

--- a/cosec-core/src/test/resources/test-policy.json
+++ b/cosec-core/src/test/resources/test-policy.json
@@ -223,6 +223,16 @@
           }
         ]
       }
+    },
+    {
+      "name": "TestInRole",
+      "effect": "allow",
+      "action": "*",
+      "condition": {
+        "inRole": {
+          "value": "admin"
+        }
+      }
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosec
-version=1.16.7
+version=1.16.8
 description=RBAC-based And Policy-based Multi-Tenant Reactive Security Framework
 website=https://github.com/Ahoo-Wang/CoSec
 issues=https://github.com/Ahoo-Wang/CoSec/issues

--- a/schema/condition.schema.json
+++ b/schema/condition.schema.json
@@ -16,6 +16,9 @@
     "inTenant": {
       "$ref": "#/definitions/inTenantConditionMatcher"
     },
+    "inRole": {
+      "$ref": "#/definitions/inRoleConditionMatcher"
+    },
     "path": {
       "$ref": "#/definitions/pathConditionMatcher"
     },
@@ -109,6 +112,20 @@
         },
         "value": {
           "$ref": "#/definitions/tenantType"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "inRoleConditionMatcher": {
+      "type": "object",
+      "properties": {
+        "negate": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION

Changes proposed in this pull request:
- feat: add `InRoleConditionMatcher`

```json 
{
  "name": "TestInRole",
  "effect": "allow",
  "action": "*",
  "condition": {
    "inRole": {
      "value": "admin"
    }
  }
}
```