### PR TITLE
feat: support `request.path.var.*` for `PartExtractor`.

### DIFF
--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/policy/Statement.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/policy/Statement.kt
@@ -24,10 +24,10 @@ interface Statement : Named, PermissionVerifier {
     val condition: ConditionMatcher
 
     override fun verify(request: Request, securityContext: SecurityContext): VerifyResult {
-        if (!condition.match(request = request, securityContext = securityContext)) {
+        if (!action.match(request = request, securityContext = securityContext)) {
             return VerifyResult.IMPLICIT_DENY
         }
-        if (!action.match(request = request, securityContext = securityContext)) {
+        if (!condition.match(request = request, securityContext = securityContext)) {
             return VerifyResult.IMPLICIT_DENY
         }
         return when (effect) {

--- a/cosec-core/src/jmh/kotlin/me/ahoo/cosec/policy/action/PathPatternBenchmark.kt
+++ b/cosec-core/src/jmh/kotlin/me/ahoo/cosec/policy/action/PathPatternBenchmark.kt
@@ -14,42 +14,17 @@
 package me.ahoo.cosec.policy.action
 
 import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.annotations.Scope
-import org.openjdk.jmh.annotations.Setup
-import org.openjdk.jmh.annotations.State
-import org.springframework.http.server.PathContainer
 import org.springframework.web.util.pattern.PathPattern
-import org.springframework.web.util.pattern.PathPatternParser
 
-@State(Scope.Benchmark)
 open class PathPatternBenchmark {
-    companion object {
-        const val path = "/api/user/CoSecId"
-    }
-
-    private lateinit var patternParser: PathPatternParser
-    private lateinit var pathPattern: PathPattern
-
-    @Setup
-    fun init() {
-        patternParser = PathPatternParser.defaultInstance
-        pathPattern = patternParser.parse("/api/user/{id}")
-    }
 
     @Benchmark
     fun matches(): Boolean {
-        PathContainer.parsePath(path, patternParser.pathOptions)
-            .let { pathContainer ->
-                return pathPattern.matches(pathContainer)
-            }
+        return PathPatternTest.matches()
     }
 
     @Benchmark
     fun matchAndExtract(): PathPattern.PathMatchInfo? {
-        PathContainer.parsePath(path, patternParser.pathOptions)
-            .let { pathContainer ->
-                return pathPattern.matchAndExtract(pathContainer)
-            }
+        return PathPatternTest.matchAndExtract()
     }
-
 }

--- a/cosec-core/src/jmh/kotlin/me/ahoo/cosec/policy/action/PathPatternBenchmark.kt
+++ b/cosec-core/src/jmh/kotlin/me/ahoo/cosec/policy/action/PathPatternBenchmark.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.policy.action
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.springframework.http.server.PathContainer
+import org.springframework.web.util.pattern.PathPattern
+import org.springframework.web.util.pattern.PathPatternParser
+
+@State(Scope.Benchmark)
+open class PathPatternBenchmark {
+    companion object {
+        const val path = "/api/user/CoSecId"
+    }
+
+    private lateinit var patternParser: PathPatternParser
+    private lateinit var pathPattern: PathPattern
+
+    @Setup
+    fun init() {
+        patternParser = PathPatternParser.defaultInstance
+        pathPattern = patternParser.parse("/api/user/{id}")
+    }
+
+    @Benchmark
+    fun matches(): Boolean {
+        PathContainer.parsePath(path, patternParser.pathOptions)
+            .let { pathContainer ->
+                return pathPattern.matches(pathContainer)
+            }
+    }
+
+    @Benchmark
+    fun matchAndExtract(): PathPattern.PathMatchInfo? {
+        PathContainer.parsePath(path, patternParser.pathOptions)
+            .let { pathContainer ->
+                return pathPattern.matchAndExtract(pathContainer)
+            }
+    }
+
+}

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/part/PartExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/part/PartExtractor.kt
@@ -15,6 +15,7 @@ package me.ahoo.cosec.policy.condition.part
 
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.policy.action.getPathVariables
 
 const val CONDITION_MATCHER_PART_KEY = "part"
 
@@ -31,6 +32,7 @@ object RequestParts {
     const val REFERER = PREFIX + "referer"
     const val HEADER_PREFIX = PREFIX + "header."
     const val ATTRIBUTES_PREFIX = PREFIX + "attributes."
+    const val PATH_VAR_PREFIX = "$PATH.var."
 }
 
 object SecurityContextParts {
@@ -65,7 +67,10 @@ data class DefaultPartExtractor(val part: String) : PartExtractor {
                     val headerKey = part.substring(SecurityContextParts.PRINCIPAL_ATTRIBUTES_PREFIX.length)
                     return securityContext.principal.attributes[headerKey].orEmpty()
                 }
-
+                if (part.startsWith(RequestParts.PATH_VAR_PREFIX)) {
+                    val pathVarKey = part.substring(RequestParts.PATH_VAR_PREFIX.length)
+                    return securityContext.getPathVariables()?.get(pathVarKey).orEmpty()
+                }
                 throw IllegalArgumentException("Unsupported part: $part")
             }
         }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/StatementDataTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/StatementDataTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.cosec.api.context.request.Request
 import me.ahoo.cosec.api.policy.Effect
 import me.ahoo.cosec.api.policy.VerifyResult
 import me.ahoo.cosec.configuration.JsonConfiguration.Companion.asConfiguration
+import me.ahoo.cosec.context.SimpleSecurityContext
 import me.ahoo.cosec.policy.action.AllActionMatcher
 import me.ahoo.cosec.policy.action.PathActionMatcherFactory
 import me.ahoo.cosec.policy.condition.AllConditionMatcher
@@ -54,7 +55,7 @@ internal class StatementDataTest {
         val request = mockk<Request> {
             every { path } returns "auth/login:POST"
         }
-        assertThat(statementData.verify(request, mockk()), `is`(VerifyResult.ALLOW))
+        assertThat(statementData.verify(request, SimpleSecurityContext.anonymous()), `is`(VerifyResult.ALLOW))
     }
 
     @Test
@@ -74,12 +75,13 @@ internal class StatementDataTest {
         val request = mockk<Request> {
             every { path } returns "order/1/search:POST"
         }
-        val securityContext = mockk<SecurityContext> {
-            every { principal } returns mockk {
+        val securityContext = SimpleSecurityContext(
+            principal = mockk {
                 every { id } returns "1"
                 every { authenticated() } returns true
             }
-        }
+        )
+
         assertThat(statementData.verify(request, securityContext), `is`(VerifyResult.ALLOW))
 
         val securityContextNotMine = mockk<SecurityContext> {

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/action/PathPatternTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/action/PathPatternTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.policy.action
+
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.Test
+import org.springframework.http.server.PathContainer
+import org.springframework.web.util.pattern.PathPattern
+import org.springframework.web.util.pattern.PathPatternParser
+
+class PathPatternTest {
+    companion object {
+        const val path = "/api/user/CoSecId"
+        val patternParser: PathPatternParser = PathPatternParser.defaultInstance
+        val pathPattern: PathPattern = patternParser.parse("/api/user/{id}")
+        fun matches(): Boolean {
+            PathContainer.parsePath(path, patternParser.pathOptions)
+                .let { pathContainer ->
+                    return pathPattern.matches(pathContainer)
+                }
+        }
+
+        fun matchAndExtract(): PathPattern.PathMatchInfo? {
+            PathContainer.parsePath(path, patternParser.pathOptions)
+                .let { pathContainer ->
+                    return pathPattern.matchAndExtract(pathContainer)
+                }
+        }
+    }
+
+    @Test
+    fun matches() {
+        assertThat(PathPatternTest.matches(), equalTo(true))
+    }
+
+    @Test
+    fun matchAndExtract() {
+        val pathMatchInfo = PathPatternTest.matchAndExtract()
+        assertThat(pathMatchInfo, notNullValue())
+        assertThat(pathMatchInfo!!.uriVariables["id"], equalTo("CoSecId"))
+    }
+}

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/action/ReplaceablePathActionMatcherTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/action/ReplaceablePathActionMatcherTest.kt
@@ -15,9 +15,9 @@ package me.ahoo.cosec.policy.action
 
 import io.mockk.every
 import io.mockk.mockk
-import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
 import me.ahoo.cosec.configuration.JsonConfiguration.Companion.asConfiguration
+import me.ahoo.cosec.context.SimpleSecurityContext
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
@@ -26,11 +26,11 @@ internal class ReplaceablePathActionMatcherTest {
 
     @Test
     fun match() {
-        val securityContext = mockk<SecurityContext> {
-            every { principal } returns mockk {
+        val securityContext = SimpleSecurityContext(
+            principal = mockk {
                 every { id } returns "1"
             }
-        }
+        )
 
         val actionMatcher =
             PathActionMatcherFactory().create("order/#{principal.id}/*".asConfiguration())

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/condition/part/DefaultPartExtractorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/condition/part/DefaultPartExtractorTest.kt
@@ -17,6 +17,7 @@ import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.policy.action.getPathVariables
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Assertions
@@ -62,6 +63,17 @@ class DefaultPartExtractorTest {
             every { referer } returns "referer"
         }
         assertThat(DefaultPartExtractor(RequestParts.REFERER).extract(request, mockk()), equalTo("referer"))
+    }
+
+    @Test
+    fun extractRequestPathVar() {
+        val context: SecurityContext = mockk {
+            every { getPathVariables() } returns mapOf("id" to "id")
+        }
+        assertThat(
+            DefaultPartExtractor(RequestParts.PATH_VAR_PREFIX + "id").extract(mockk(), context),
+            equalTo("id")
+        )
     }
 
     @Test

--- a/cosec-core/src/test/resources/test-policy.json
+++ b/cosec-core/src/test/resources/test-policy.json
@@ -233,6 +233,16 @@
           "value": "admin"
         }
       }
+    },
+    {
+      "name": "RequestPathVar",
+      "action": "/user/{id}",
+      "condition": {
+        "eq": {
+          "part": "request.path.var.id",
+          "value": "userId"
+        }
+      }
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosec
-version=2.1.4
+version=2.2.0
 description=RBAC-based And Policy-based Multi-Tenant Reactive Security Framework.
 website=https://github.com/Ahoo-Wang/CoSec
 issues=https://github.com/Ahoo-Wang/CoSec/issues

--- a/schema/condition.schema.json
+++ b/schema/condition.schema.json
@@ -73,6 +73,7 @@
         "request.header.cosec-app-id",
         "request.attributes.",
         "request.attributes.ipRegion",
+        "request.path.var.",
         "context.tenantId",
         "context.principal.id",
         "context.principal.attributes."


### PR DESCRIPTION
```json
    {
      "name": "RequestPathVar",
      "action": "/user/{id}",
      "condition": {
        "eq": {
          "part": "request.path.var.id",
          "value": "userId"
        }
      }
    }
```