### PR TITLE
build(deps): update cocache version to 3.0.5

### DIFF
--- a/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/AppPermissionCache.kt
+++ b/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/AppPermissionCache.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.cosec.redis
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.api.Cache
 import me.ahoo.cosec.Delegated
 import me.ahoo.cosec.api.permission.AppPermission
 

--- a/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/GlobalPolicyIndexCache.kt
+++ b/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/GlobalPolicyIndexCache.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cosec.redis
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.api.Cache
 import me.ahoo.cosec.Delegated
 
 /**

--- a/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/GlobalPolicyIndexKeyConverter.kt
+++ b/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/GlobalPolicyIndexKeyConverter.kt
@@ -16,7 +16,7 @@ package me.ahoo.cosec.redis
 import me.ahoo.cache.converter.KeyConverter
 
 class GlobalPolicyIndexKeyConverter(private val key: String) : KeyConverter<String> {
-    override fun asKey(sourceKey: String): String {
+    override fun toStringKey(sourceKey: String): String {
         return key
     }
 

--- a/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/PolicyCache.kt
+++ b/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/PolicyCache.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cosec.redis
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.api.Cache
 import me.ahoo.cosec.Delegated
 import me.ahoo.cosec.api.policy.Policy
 

--- a/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/RolePermissionCache.kt
+++ b/cosec-redis/src/main/kotlin/me/ahoo/cosec/redis/RolePermissionCache.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.cosec.redis
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.api.Cache
 import me.ahoo.cosec.Delegated
 
 class RolePermissionCache(override val delegate: Cache<String, Set<String>>) :

--- a/cosec-redis/src/test/kotlin/me/ahoo/cosec/redis/AppPermissionCodecExecutorTest.kt
+++ b/cosec-redis/src/test/kotlin/me/ahoo/cosec/redis/AppPermissionCodecExecutorTest.kt
@@ -12,8 +12,9 @@
  */
 package me.ahoo.cosec.redis
 
-import me.ahoo.cache.CacheValue
-import me.ahoo.cache.TtlAt
+import me.ahoo.cache.ComputedTtlAt
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.spring.redis.codec.ObjectToJsonCodecExecutor
 import me.ahoo.cosec.api.permission.AppPermission
 import me.ahoo.cosec.permission.AppPermissionData
@@ -67,18 +68,18 @@ internal class AppPermissionCodecExecutorTest {
             ),
         )
         val key = "app:" + MockIdGenerator.INSTANCE.generateAsString()
-        val cacheValue: CacheValue<AppPermission> = CacheValue.forever(appPermission)
+        val cacheValue: CacheValue<AppPermission> = DefaultCacheValue.forever(appPermission)
         codecExecutor.executeAndEncode(key, cacheValue)
-        val (value) = codecExecutor.executeAndDecode(key, TtlAt.FOREVER)
+        val value = codecExecutor.executeAndDecode(key, ComputedTtlAt.FOREVER).value
         assertThat(value, `is`(appPermission))
     }
 
     @Test
     fun executeAndEncodeMissing() {
         val key = "app:" + MockIdGenerator.INSTANCE.generateAsString()
-        val cacheValue: CacheValue<AppPermission> = CacheValue.missingGuard()
+        val cacheValue: CacheValue<AppPermission> = DefaultCacheValue.missingGuard()
         codecExecutor.executeAndEncode(key, cacheValue)
-        val actual = codecExecutor.executeAndDecode(key, TtlAt.FOREVER)
+        val actual = codecExecutor.executeAndDecode(key, ComputedTtlAt.FOREVER)
         assertThat(actual, `is`(cacheValue))
     }
 }

--- a/cosec-redis/src/test/kotlin/me/ahoo/cosec/redis/GlobalPolicyIndexKeyConverterTest.kt
+++ b/cosec-redis/src/test/kotlin/me/ahoo/cosec/redis/GlobalPolicyIndexKeyConverterTest.kt
@@ -9,7 +9,7 @@ class GlobalPolicyIndexKeyConverterTest {
 
     @Test
     fun asKey() {
-        assertThat(keyConverter.asKey(""), equalTo("key"))
+        assertThat(keyConverter.toStringKey(""), equalTo("key"))
     }
 
     @Test

--- a/cosec-redis/src/test/kotlin/me/ahoo/cosec/redis/PolicyCodecExecutorTest.kt
+++ b/cosec-redis/src/test/kotlin/me/ahoo/cosec/redis/PolicyCodecExecutorTest.kt
@@ -12,8 +12,9 @@
  */
 package me.ahoo.cosec.redis
 
-import me.ahoo.cache.CacheValue
-import me.ahoo.cache.TtlAt
+import me.ahoo.cache.ComputedTtlAt
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.spring.redis.codec.ObjectToJsonCodecExecutor
 import me.ahoo.cosec.api.policy.Policy
 import me.ahoo.cosec.api.policy.PolicyType
@@ -67,18 +68,18 @@ internal class PolicyCodecExecutorTest {
             statements = listOf(StatementData(action = AllActionMatcher.INSTANCE)),
         )
         val key = "policy:" + MockIdGenerator.INSTANCE.generateAsString()
-        val cacheValue: CacheValue<Policy> = CacheValue.forever(policy)
+        val cacheValue: CacheValue<Policy> = DefaultCacheValue.forever(policy)
         codecExecutor.executeAndEncode(key, cacheValue)
-        val (value) = codecExecutor.executeAndDecode(key, TtlAt.FOREVER)
+        val value = codecExecutor.executeAndDecode(key, ComputedTtlAt.FOREVER).value
         assertThat(value, `is`(policy))
     }
 
     @Test
     fun executeAndEncodeMissing() {
         val key = "policy:" + MockIdGenerator.INSTANCE.generateAsString()
-        val cacheValue: CacheValue<Policy> = CacheValue.missingGuard()
+        val cacheValue: CacheValue<Policy> = DefaultCacheValue.missingGuard()
         codecExecutor.executeAndEncode(key, cacheValue)
-        val actual = codecExecutor.executeAndDecode(key, TtlAt.FOREVER)
+        val actual = codecExecutor.executeAndDecode(key, ComputedTtlAt.FOREVER)
         assertThat(actual, `is`(cacheValue))
     }
 }

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecPermissionCacheAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecPermissionCacheAutoConfiguration.kt
@@ -14,8 +14,8 @@ package me.ahoo.cosec.spring.boot.starter.authorization.cache
 
 import me.ahoo.cache.CacheConfig
 import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CacheSource
-import me.ahoo.cache.CacheSource.Companion.noOp
+import me.ahoo.cache.api.source.CacheSource
+import me.ahoo.cache.api.source.CacheSource.Companion.noOp
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.spring.redis.RedisDistributedCache

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecPolicyCacheAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecPolicyCacheAutoConfiguration.kt
@@ -14,8 +14,8 @@ package me.ahoo.cosec.spring.boot.starter.authorization.cache
 
 import me.ahoo.cache.CacheConfig
 import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CacheSource
-import me.ahoo.cache.CacheSource.Companion.noOp
+import me.ahoo.cache.api.source.CacheSource
+import me.ahoo.cache.api.source.CacheSource.Companion.noOp
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.spring.redis.RedisDistributedCache

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosec
-version=2.10.2
+version=2.10.5
 description=RBAC-based And Policy-based Multi-Tenant Reactive Security Framework.
 website=https://github.com/Ahoo-Wang/CoSec
 issues=https://github.com/Ahoo-Wang/CoSec/issues

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 spring-boot = "3.4.3"
 spring-cloud = "2024.0.0"
 cosid = "2.11.0"
-cocache = "2.6.3"
+cocache = "3.0.0"
 opentelemetry = "2.13.2"
 testcontainers = "1.20.5"
 guava = "33.4.0-jre"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 spring-boot = "3.4.3"
 spring-cloud = "2024.0.0"
 cosid = "2.11.0"
-cocache = "3.0.0"
+cocache = "3.0.5"
 opentelemetry = "2.13.2"
 testcontainers = "1.20.5"
 guava = "33.4.0-jre"


### PR DESCRIPTION
- Update cocache dependency from 2.6.3 to 3.0.0
- Refactor import statements to use api packages instead of internal implementations
- Update CacheValue and TtlAt usages to their new package locations
