### PR TITLE
refactor(cache): Refactoring permission cache implementation

### DIFF
--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/AppPermissionCache.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/AppPermissionCache.kt
@@ -14,9 +14,6 @@
 package me.ahoo.cosec.cache
 
 import me.ahoo.cache.api.Cache
-import me.ahoo.cosec.Delegated
 import me.ahoo.cosec.api.permission.AppPermission
 
-class AppPermissionCache(override val delegate: Cache<String, AppPermission>) :
-    Cache<String, AppPermission> by delegate,
-    Delegated<Cache<String, AppPermission>>
+interface AppPermissionCache : Cache<String, AppPermission>

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/GlobalPolicyIndexCache.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/GlobalPolicyIndexCache.kt
@@ -13,16 +13,13 @@
 package me.ahoo.cosec.cache
 
 import me.ahoo.cache.api.Cache
-import me.ahoo.cosec.Delegated
 
 /**
  * Global Policy Index Cache .
  *
  * @author ahoo wang
  */
-class GlobalPolicyIndexCache(override val delegate: Cache<String, Set<String>>) :
-    Cache<String, Set<String>> by delegate,
-    Delegated<Cache<String, Set<String>>> {
+interface GlobalPolicyIndexCache : Cache<String, Set<String>> {
     companion object {
         const val CACHE_KEY = ""
     }

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/PolicyCache.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/PolicyCache.kt
@@ -13,7 +13,6 @@
 package me.ahoo.cosec.cache
 
 import me.ahoo.cache.api.Cache
-import me.ahoo.cosec.Delegated
 import me.ahoo.cosec.api.policy.Policy
 
 /**
@@ -21,6 +20,4 @@ import me.ahoo.cosec.api.policy.Policy
  *
  * @author ahoo wang
  */
-class PolicyCache(override val delegate: Cache<String, Policy>) :
-    Cache<String, Policy> by delegate,
-    Delegated<Cache<String, Policy>>
+interface PolicyCache : Cache<String, Policy>

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/RolePermissionCache.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/RolePermissionCache.kt
@@ -14,8 +14,5 @@
 package me.ahoo.cosec.cache
 
 import me.ahoo.cache.api.Cache
-import me.ahoo.cosec.Delegated
 
-class RolePermissionCache(override val delegate: Cache<String, Set<String>>) :
-    Cache<String, Set<String>> by delegate,
-    Delegated<Cache<String, Set<String>>>
+interface RolePermissionCache : Cache<String, Set<String>>

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecPermissionCacheAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecPermissionCacheAutoConfigurationTest.kt
@@ -43,7 +43,7 @@ internal class CoSecPermissionCacheAutoConfigurationTest {
                     .hasSingleBean(CoSecPermissionCacheAutoConfiguration::class.java)
                     .hasBean(CoSecPermissionCacheAutoConfiguration.APP_PERMISSION_CACHE_BEAN_NAME)
                     .hasSingleBean(AppPermissionCache::class.java)
-                    .hasBean(CoSecPermissionCacheAutoConfiguration.Role_PERMISSION_CACHE_BEAN_NAME)
+                    .hasBean(CoSecPermissionCacheAutoConfiguration.ROLE_PERMISSION_CACHE_BEAN_NAME)
                     .hasSingleBean(RolePermissionCache::class.java)
                     .hasSingleBean(AppRolePermissionRepository::class.java)
             }

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecPolicyCacheAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CoSecPolicyCacheAutoConfigurationTest.kt
@@ -41,9 +41,8 @@ internal class CoSecPolicyCacheAutoConfigurationTest {
                 assertThat(context)
                     .hasSingleBean(CacheProperties::class.java)
                     .hasSingleBean(CoSecPolicyCacheAutoConfiguration::class.java)
-                    .hasBean(CoSecPolicyCacheAutoConfiguration.GLOBAL_POLICY_INDEX_CACHE_SOURCE_BEAN_NAME)
                     .hasSingleBean(GlobalPolicyIndexCache::class.java)
-                    .hasBean(CoSecPolicyCacheAutoConfiguration.POLICY_CACHE_SOURCE_BEAN_NAME)
+                    .hasBean(CoSecPolicyCacheAutoConfiguration.POLICY_CACHE_BEAN_NAME)
                     .hasSingleBean(PolicyCache::class.java)
                     .hasSingleBean(PolicyRepository::class.java)
             }


### PR DESCRIPTION
- Change AppPermissionCache, GlobalPolicyIndexCache, PolicyCache, and RolePermissionCache from class to interface
- Remove inheritance of Delegated interfaces
- Update cache configuration and automatic configuration logic
- Adjust test cases to fit new cache interfaces