### PR TITLE
feat(cosec-gateway-server): add cache configuration for policy and role

### DIFF
--- a/cosec-gateway-server/src/dist/config/application.yaml
+++ b/cosec-gateway-server/src/dist/config/application.yaml
@@ -9,3 +9,8 @@ cosec:
     local-policy:
       enabled: true
       init-repository: true
+    cache:
+      policy:
+        maximum-size: 100000
+      role:
+        maximum-size: 100000

--- a/cosec-gateway-server/src/main/resources/application.yaml
+++ b/cosec-gateway-server/src/main/resources/application.yaml
@@ -41,6 +41,12 @@ cosec:
     local-policy:
       enabled: true
       init-repository: true
+    cache:
+      policy:
+        maximum-size: 100000
+      role:
+        maximum-size: 100000
+
 logging:
   level:
     root: info


### PR DESCRIPTION
- Add cache configuration to improve performance for policy and role retrieval
- Set maximum size for policy cache and role cache to 100,000 entries each
- Update configuration in both distribution and main resource files
