### PR TITLE
build(gradle): add JVM arguments for parameter names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,11 @@ configure(libraryProjects) {
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             freeCompilerArgs = listOf("-Xjsr305=strict", "-Xjvm-default=all-compatibility")
+            javaParameters = true
         }
+    }
+    tasks.withType<JavaCompile> {
+        options.compilerArgs.addAll(listOf("-parameters"))
     }
     apply<me.champeau.jmh.JMHPlugin>()
     configure<me.champeau.jmh.JmhParameters> {


### PR DESCRIPTION
- Add `javaParameters = true` to Kotlin compiler options
- Add `-parameters` to Java compiler arguments
- These changes enable proper handling of parameter names in mixed-language projects