### PR TITLE
build(deps): update dependencies and move logging to api scope

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,7 +137,6 @@ configure(libraryProjects) {
         jmh(platform(dependenciesProject))
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
-        implementation("io.github.oshai:kotlin-logging-jvm")
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("org.hamcrest:hamcrest")
         testImplementation("io.mockk:mockk") {

--- a/cosec-core/build.gradle.kts
+++ b/cosec-core/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     compileOnly("ognl:ognl")
     compileOnly("org.springframework:spring-web")
     compileOnly("org.springframework:spring-expression")
+    api("io.github.oshai:kotlin-logging-jvm")
     api("io.projectreactor:reactor-core")
     api("io.projectreactor.kotlin:reactor-kotlin-extensions")
     api("com.fasterxml.jackson.core:jackson-databind")


### PR DESCRIPTION
- Move `kotlin-logging-jvm` from implementation to api scope in cosec-core
- Remove `kotlin-logging-jvm` from root project dependencies