### PR TITLE
feat(core): add query parameter support for authorization header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,7 @@ configure(libraryProjects) {
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
         testImplementation("ch.qos.logback:logback-classic")
+        testImplementation("me.ahoo.test:fluent-assert-core")
         testImplementation("org.hamcrest:hamcrest")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")

--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/Request.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/Request.kt
@@ -30,4 +30,5 @@ interface Request : Attributes<Request, String, String> {
     val origin: String
     val referer: String
     fun getHeader(key: String): String
+    fun getQuery(key: String): String
 }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/DefaultSecurityContextParser.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/DefaultSecurityContextParser.kt
@@ -23,8 +23,16 @@ import me.ahoo.cosec.token.SimpleAccessToken
  * @author ahoo wang
  */
 open class DefaultSecurityContextParser(private val principalConverter: PrincipalConverter) : SecurityContextParser {
-    override fun parse(request: Request): SecurityContext {
+    private fun getAuthorization(request: Request): String {
         val authorization = request.getHeader(AUTHORIZATION_HEADER_KEY)
+        if (authorization.isNotBlank()) {
+            return authorization
+        }
+        return request.getQuery(AUTHORIZATION_HEADER_KEY)
+    }
+
+    override fun parse(request: Request): SecurityContext {
+        val authorization = getAuthorization(request)
         if (authorization.isBlank()) {
             return SimpleSecurityContext.anonymous()
         }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluator.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluator.kt
@@ -67,6 +67,10 @@ data class EvaluateRequest(override val attributes: Map<String, String> = mapOf(
         return key
     }
 
+    override fun getQuery(key: String): String {
+        return key
+    }
+
     override fun withAttributes(attributes: Map<String, String>): Request {
         return copy(attributes = attributes)
     }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/SecurityContextHolderTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/SecurityContextHolderTest.kt
@@ -14,21 +14,19 @@
 package me.ahoo.cosec.context
 
 import me.ahoo.cosec.principal.SimpleTenantPrincipal
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.nullValue
-import org.junit.jupiter.api.Assertions
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import org.junit.jupiter.api.Test
 
 internal class SecurityContextHolderTest {
 
     @Test
     fun test() {
-        assertThat(SecurityContextHolder.context, nullValue())
+        SecurityContextHolder.context.assert().isNull()
         SecurityContextHolder.setContext(SimpleSecurityContext.anonymous())
-        assertThat(SecurityContextHolder.context!!.principal, equalTo(SimpleTenantPrincipal.ANONYMOUS))
+        SecurityContextHolder.context!!.principal.assert().isEqualTo(SimpleTenantPrincipal.ANONYMOUS)
         SecurityContextHolder.remove()
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertThrownBy<IllegalArgumentException> {
             SecurityContextHolder.requiredContext
         }
     }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/SecurityContextTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/SecurityContextTest.kt
@@ -15,11 +15,9 @@ package me.ahoo.cosec.context
 
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.principal.SimplePrincipal
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.`is`
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 internal class SecurityContextTest {
 
@@ -27,10 +25,10 @@ internal class SecurityContextTest {
     fun test() {
         val context: SecurityContext = SimpleSecurityContext(SimplePrincipal.ANONYMOUS)
         context.setAttributeValue("key", "value")
-        assertThat(context.getRequiredAttributeValue("key"), `is`("value"))
-        assertThat(context.principal, equalTo(SimplePrincipal.ANONYMOUS))
-        assertThat(context.tenant, equalTo(SimplePrincipal.ANONYMOUS.tenant))
-        assertThrows<IllegalArgumentException> {
+        context.getRequiredAttributeValue<String>("key").assert().isEqualTo("value")
+        context.principal.assert().isEqualTo(SimplePrincipal.ANONYMOUS)
+        context.tenant.assert().isEqualTo(SimplePrincipal.ANONYMOUS.tenant)
+        assertThrownBy<IllegalArgumentException> {
             context.getRequiredAttributeValue("not-exists")
         }
     }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/XForwardedRemoteIpResolverTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/XForwardedRemoteIpResolverTest.kt
@@ -15,8 +15,7 @@ package me.ahoo.cosec.context.request
 
 import io.mockk.mockk
 import me.ahoo.cosec.api.context.request.Request
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class XForwardedRemoteIpResolverTest {
@@ -29,7 +28,7 @@ class XForwardedRemoteIpResolverTest {
                 return listOf("", "")
             }
         }
-        assertThat(xForwardedRemoteIpResolver.resolve(mockk()), `is`("default"))
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("default")
     }
 
     @Test
@@ -39,7 +38,7 @@ class XForwardedRemoteIpResolverTest {
                 return null
             }
         }
-        assertThat(xForwardedRemoteIpResolver.resolve(mockk()), `is`("default"))
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("default")
     }
 
     @Test
@@ -49,7 +48,7 @@ class XForwardedRemoteIpResolverTest {
                 return listOf("ipAddress")
             }
         }
-        assertThat(xForwardedRemoteIpResolver.resolve(mockk()), `is`("ipAddress"))
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("ipAddress")
     }
 
     @Test
@@ -59,6 +58,6 @@ class XForwardedRemoteIpResolverTest {
                 return listOf("ipAddress0, ipAddress1, ipAddress2")
             }
         }
-        assertThat(xForwardedRemoteIpResolver.resolve(mockk()), `is`("ipAddress0"))
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("ipAddress0")
     }
 }

--- a/cosec-dependencies/build.gradle.kts
+++ b/cosec-dependencies/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(platform(libs.cocache.bom))
     api(platform(libs.justAuth))
     api(platform(libs.opentelemetry.instrumentation.bom))
+    api(platform(libs.fluent.assert.bom))
     constraints {
         api(libs.ognl)
         api(libs.java.jwt)

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequest.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequest.kt
@@ -31,6 +31,10 @@ data class ReactiveRequest(
         return delegate.request.headers.getFirst(key).orEmpty()
     }
 
+    override fun getQuery(key: String): String {
+        return delegate.request.queryParams.getFirst(key).orEmpty()
+    }
+
     override fun withAttributes(attributes: Map<String, String>): Request = copy(attributes = attributes)
 
     override fun toString(): String {

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/CoSecServletRequest.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/CoSecServletRequest.kt
@@ -29,6 +29,9 @@ data class CoSecServletRequest(
     override fun getHeader(key: String): String {
         return delegate.getHeader(key).orEmpty()
     }
+    override fun getQuery(key: String): String {
+        return delegate.getParameter(key).orEmpty()
+    }
 
     override fun withAttributes(attributes: Map<String, String>): Request = copy(attributes = attributes)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ java-jwt = "4.5.0"
 ip2region = "2.7.0"
 justAuth = "1.16.7"
 swagger = "2.2.30"
+# testing
+fluent-assert = "0.1.0"
 hamcrest = "3.0"
 mockk = "1.14.0"
 jmh = "1.37"
@@ -36,6 +38,7 @@ java-jwt = { module = "com.auth0:java-jwt", version.ref = "java-jwt" }
 ip2region = { module = "org.lionsoul:ip2region", version.ref = "ip2region" }
 justAuth = { module = "me.zhyd.oauth:JustAuth", version.ref = "justAuth" }
 swagger = { module = "io.swagger.core.v3:swagger-core-jakarta", version.ref = "swagger" }
+fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }


### PR DESCRIPTION
- Add getQuery method to Request interface
- Implement getQuery in CoSecServletRequest and ReactiveRequest
- Update DefaultPolicyEvaluator to use getQuery
- Modify DefaultSecurityContextParser to check query parameters for authorization
- Add tests for query parameter authorization
- Update build.gradle.kts to include fluent-assert dependency

