### PR TITLE
test: refactor test assertions and add query parameter checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,7 @@ configure(libraryProjects) {
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
         testImplementation("ch.qos.logback:logback-classic")
+        testImplementation("me.ahoo.test:fluent-assert-core")
         testImplementation("org.hamcrest:hamcrest")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")

--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/Request.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/Request.kt
@@ -30,4 +30,5 @@ interface Request : Attributes<Request, String, String> {
     val origin: String
     val referer: String
     fun getHeader(key: String): String
+    fun getQuery(key: String): String
 }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/DefaultSecurityContextParser.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/DefaultSecurityContextParser.kt
@@ -23,8 +23,16 @@ import me.ahoo.cosec.token.SimpleAccessToken
  * @author ahoo wang
  */
 open class DefaultSecurityContextParser(private val principalConverter: PrincipalConverter) : SecurityContextParser {
-    override fun parse(request: Request): SecurityContext {
+    private fun getAuthorization(request: Request): String {
         val authorization = request.getHeader(AUTHORIZATION_HEADER_KEY)
+        if (authorization.isNotBlank()) {
+            return authorization
+        }
+        return request.getQuery(AUTHORIZATION_HEADER_KEY)
+    }
+
+    override fun parse(request: Request): SecurityContext {
+        val authorization = getAuthorization(request)
         if (authorization.isBlank()) {
             return SimpleSecurityContext.anonymous()
         }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluator.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluator.kt
@@ -67,6 +67,10 @@ data class EvaluateRequest(override val attributes: Map<String, String> = mapOf(
         return key
     }
 
+    override fun getQuery(key: String): String {
+        return key
+    }
+
     override fun withAttributes(attributes: Map<String, String>): Request {
         return copy(attributes = attributes)
     }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/SecurityContextHolderTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/SecurityContextHolderTest.kt
@@ -14,21 +14,19 @@
 package me.ahoo.cosec.context
 
 import me.ahoo.cosec.principal.SimpleTenantPrincipal
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.nullValue
-import org.junit.jupiter.api.Assertions
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import org.junit.jupiter.api.Test
 
 internal class SecurityContextHolderTest {
 
     @Test
     fun test() {
-        assertThat(SecurityContextHolder.context, nullValue())
+        SecurityContextHolder.context.assert().isNull()
         SecurityContextHolder.setContext(SimpleSecurityContext.anonymous())
-        assertThat(SecurityContextHolder.context!!.principal, equalTo(SimpleTenantPrincipal.ANONYMOUS))
+        SecurityContextHolder.context!!.principal.assert().isEqualTo(SimpleTenantPrincipal.ANONYMOUS)
         SecurityContextHolder.remove()
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertThrownBy<IllegalArgumentException> {
             SecurityContextHolder.requiredContext
         }
     }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/SecurityContextTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/SecurityContextTest.kt
@@ -15,11 +15,9 @@ package me.ahoo.cosec.context
 
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.principal.SimplePrincipal
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.`is`
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 internal class SecurityContextTest {
 
@@ -27,10 +25,10 @@ internal class SecurityContextTest {
     fun test() {
         val context: SecurityContext = SimpleSecurityContext(SimplePrincipal.ANONYMOUS)
         context.setAttributeValue("key", "value")
-        assertThat(context.getRequiredAttributeValue("key"), `is`("value"))
-        assertThat(context.principal, equalTo(SimplePrincipal.ANONYMOUS))
-        assertThat(context.tenant, equalTo(SimplePrincipal.ANONYMOUS.tenant))
-        assertThrows<IllegalArgumentException> {
+        context.getRequiredAttributeValue<String>("key").assert().isEqualTo("value")
+        context.principal.assert().isEqualTo(SimplePrincipal.ANONYMOUS)
+        context.tenant.assert().isEqualTo(SimplePrincipal.ANONYMOUS.tenant)
+        assertThrownBy<IllegalArgumentException> {
             context.getRequiredAttributeValue("not-exists")
         }
     }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/XForwardedRemoteIpResolverTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/XForwardedRemoteIpResolverTest.kt
@@ -15,8 +15,7 @@ package me.ahoo.cosec.context.request
 
 import io.mockk.mockk
 import me.ahoo.cosec.api.context.request.Request
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class XForwardedRemoteIpResolverTest {
@@ -29,7 +28,7 @@ class XForwardedRemoteIpResolverTest {
                 return listOf("", "")
             }
         }
-        assertThat(xForwardedRemoteIpResolver.resolve(mockk()), `is`("default"))
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("default")
     }
 
     @Test
@@ -39,7 +38,7 @@ class XForwardedRemoteIpResolverTest {
                 return null
             }
         }
-        assertThat(xForwardedRemoteIpResolver.resolve(mockk()), `is`("default"))
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("default")
     }
 
     @Test
@@ -49,7 +48,7 @@ class XForwardedRemoteIpResolverTest {
                 return listOf("ipAddress")
             }
         }
-        assertThat(xForwardedRemoteIpResolver.resolve(mockk()), `is`("ipAddress"))
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("ipAddress")
     }
 
     @Test
@@ -59,6 +58,6 @@ class XForwardedRemoteIpResolverTest {
                 return listOf("ipAddress0, ipAddress1, ipAddress2")
             }
         }
-        assertThat(xForwardedRemoteIpResolver.resolve(mockk()), `is`("ipAddress0"))
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("ipAddress0")
     }
 }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluatorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluatorTest.kt
@@ -23,6 +23,7 @@ import me.ahoo.cosec.api.policy.Statement
 import me.ahoo.cosec.api.policy.VerifyResult
 import me.ahoo.cosec.policy.action.AllActionMatcher
 import me.ahoo.cosec.policy.condition.AllConditionMatcher
+import me.ahoo.test.asserts.assert
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
@@ -34,14 +35,15 @@ internal class DefaultPolicyEvaluatorTest {
     @Test
     fun evaluateRequest() {
         var evaluateRequest: Request = EvaluateRequest()
-        assertThat(evaluateRequest.method, equalTo("POST"))
-        assertThat(evaluateRequest.remoteIp, equalTo("127.0.0.1"))
-        assertThat(evaluateRequest.origin, equalTo("mockOrigin"))
-        assertThat(evaluateRequest.referer, equalTo("mockReferer"))
-        assertThat(evaluateRequest.getHeader("key"), equalTo("key"))
-        assertThat(evaluateRequest.attributes, equalTo(mapOf()))
+        evaluateRequest.method.assert().isEqualTo("POST")
+        evaluateRequest.remoteIp.assert().isEqualTo("127.0.0.1")
+        evaluateRequest.origin.assert().isEqualTo("mockOrigin")
+        evaluateRequest.referer.assert().isEqualTo("mockReferer")
+        evaluateRequest.getHeader("key").assert().isEqualTo("key")
+        evaluateRequest.getQuery("key").assert().isEqualTo("key")
+        evaluateRequest.attributes.assert().isEmpty()
         evaluateRequest = evaluateRequest.withAttributes(mapOf("key" to "value"))
-        assertThat(evaluateRequest.attributes["key"], equalTo("value"))
+        evaluateRequest.attributes.assert().containsKey("key")
     }
 
     @Test

--- a/cosec-dependencies/build.gradle.kts
+++ b/cosec-dependencies/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(platform(libs.cocache.bom))
     api(platform(libs.justAuth))
     api(platform(libs.opentelemetry.instrumentation.bom))
+    api(platform(libs.fluent.assert.bom))
     constraints {
         api(libs.ognl)
         api(libs.java.jwt)

--- a/cosec-gateway/src/test/kotlin/me/ahoo/cosec/gateway/AuthorizationGatewayFilterTest.kt
+++ b/cosec-gateway/src/test/kotlin/me/ahoo/cosec/gateway/AuthorizationGatewayFilterTest.kt
@@ -51,6 +51,7 @@ class AuthorizationGatewayFilterTest {
         assertThat(filter.order, equalTo(Ordered.HIGHEST_PRECEDENCE + 10))
         val exchange = mockk<ServerWebExchange> {
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
+            every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.headers.origin } returns "origin"
             every { request.headers.getFirst(HttpHeaders.REFERER) } returns "REFERER"
             every { request.path.value() } returns "/path"

--- a/cosec-webflux/build.gradle.kts
+++ b/cosec-webflux/build.gradle.kts
@@ -18,5 +18,6 @@ dependencies {
     api("org.springframework:spring-web")
     api("org.springframework:spring-webflux")
     testImplementation("me.ahoo.cosid:cosid-test")
+    testImplementation("org.springframework:spring-test")
     testImplementation("io.projectreactor:reactor-test")
 }

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequest.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequest.kt
@@ -31,6 +31,10 @@ data class ReactiveRequest(
         return delegate.request.headers.getFirst(key).orEmpty()
     }
 
+    override fun getQuery(key: String): String {
+        return delegate.request.queryParams.getFirst(key).orEmpty()
+    }
+
     override fun withAttributes(attributes: Map<String, String>): Request = copy(attributes = attributes)
 
     override fun toString(): String {

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
@@ -65,6 +65,7 @@ internal class ReactiveAuthorizationFilterTest {
         assertThat(filter.order, equalTo(Ordered.HIGHEST_PRECEDENCE + 10))
         val exchange = mockk<ServerWebExchange> {
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
+            every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.headers.origin } returns "origin"
             every { request.headers.getFirst(HttpHeaders.REFERER) } returns "REFERER"
             every { request.path.value() } returns "/path"
@@ -143,6 +144,7 @@ internal class ReactiveAuthorizationFilterTest {
         )
         val exchange = mockk<ServerWebExchange> {
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
+            every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.headers.origin } returns "origin"
             every { request.headers.getFirst(HttpHeaders.REFERER) } returns "REFERER"
             every { request.path.value() } returns "/path"
@@ -225,6 +227,7 @@ internal class ReactiveAuthorizationFilterTest {
         )
         val exchange = mockk<ServerWebExchange> {
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
+            every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.headers.origin } returns "origin"
             every { request.headers.getFirst(HttpHeaders.REFERER) } returns "REFERER"
             every { request.path.value() } returns "/path"

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveInjectSecurityContextWebFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveInjectSecurityContextWebFilterTest.kt
@@ -21,8 +21,9 @@ import io.mockk.verify
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.jwt.InjectSecurityContextParser
 import me.ahoo.cosec.webflux.ServerWebExchanges.setSecurityContext
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.springframework.core.Ordered
 import org.springframework.http.HttpHeaders
@@ -38,6 +39,8 @@ internal class ReactiveInjectSecurityContextWebFilterTest {
             ReactiveRequestParser(ReactiveRemoteIpResolver),
             InjectSecurityContextParser
         )
+        filter.order.assert().isEqualTo(Ordered.HIGHEST_PRECEDENCE + 10)
+
         assertThat(filter.order, equalTo(Ordered.HIGHEST_PRECEDENCE + 10))
         val exchange = mockk<ServerWebExchange> {
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestTest.kt
@@ -13,20 +13,19 @@
 
 package me.ahoo.cosec.webflux
 
-import io.mockk.every
-import io.mockk.mockk
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
-import org.springframework.web.server.ServerWebExchange
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
 
 class ReactiveRequestTest {
     @Test
     fun test() {
-        val delegate = mockk<ServerWebExchange> {
-            every { request.headers.getFirst("key") } returns "value"
-            every { request.headers.getFirst("not-exists") } returns null
-        }
+        val serverRequest = MockServerHttpRequest.get("")
+            .header("key", "value")
+            .queryParam("key", "value")
+        val delegate = MockServerWebExchange.from(serverRequest)
+
         val request = ReactiveRequest(
             delegate = delegate,
             path = "path",
@@ -35,19 +34,12 @@ class ReactiveRequestTest {
             origin = "origin",
             referer = "referer",
         ).withAttributes(emptyMap())
-        assertThat(
-            request.toString(),
-            `is`(
+        request.toString().assert()
+            .isEqualTo(
                 "ReactiveRequest(path='path', method='method', remoteIp='remoteIp', origin='origin', referer='referer')"
-            ),
-        )
-        assertThat(
-            request.getHeader("key"),
-            `is`("value"),
-        )
-        assertThat(
-            request.getHeader("not-exists"),
-            `is`(""),
-        )
+            )
+        request.getHeader("key").assert().isEqualTo("value")
+        request.getHeader("not-exists").assert().isEqualTo("")
+        request.getQuery("key").assert().isEqualTo("value")
     }
 }

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityContextsTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityContextsTest.kt
@@ -19,6 +19,7 @@ import me.ahoo.cosec.principal.SimpleTenantPrincipal
 import me.ahoo.cosec.webflux.ReactiveSecurityContexts.getSecurityContext
 import me.ahoo.cosec.webflux.ReactiveSecurityContexts.getSecurityContextOrEmpty
 import me.ahoo.cosec.webflux.ReactiveSecurityContexts.writeSecurityContext
+import me.ahoo.test.asserts.assert
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Assertions
@@ -36,7 +37,7 @@ class ReactiveSecurityContextsTest {
             .test()
             .expectAccessibleContext()
             .assertThat {
-                assertThat(it.getSecurityContext().principal, equalTo(SimpleTenantPrincipal.ANONYMOUS))
+                it.getSecurityContext().principal.assert().isEqualTo(SimpleTenantPrincipal.ANONYMOUS)
             }
             .hasKey(SecurityContext.KEY)
             .then()
@@ -48,7 +49,7 @@ class ReactiveSecurityContextsTest {
         Context.empty()
             .getSecurityContextOrEmpty()
             .let {
-                assertThat(it, equalTo(null))
+                it.assert().isNull()
             }
         Assertions.assertThrows(IllegalStateException::class.java) {
             Context.empty().getSecurityContext()

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveXForwardedRemoteIpResolverTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveXForwardedRemoteIpResolverTest.kt
@@ -13,24 +13,22 @@
 
 package me.ahoo.cosec.webflux
 
-import com.google.common.net.HttpHeaders.X_FORWARDED_FOR
-import io.mockk.every
-import io.mockk.mockk
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.cosec.context.request.XForwardedRemoteIpResolver.Companion.X_FORWARDED_FOR
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
-import org.springframework.web.server.ServerWebExchange
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
 
 class ReactiveXForwardedRemoteIpResolverTest {
 
     @Test
     fun extractXForwardedHeaderValues() {
         val xForwardedRemoteIpResolver = ReactiveXForwardedRemoteIpResolver()
-        assertThat(xForwardedRemoteIpResolver.maxTrustedIndex, equalTo(Int.MAX_VALUE))
-        val serverWebExchange = mockk<ServerWebExchange> {
-            every { request.headers.get(X_FORWARDED_FOR) } returns listOf("localhost")
-        }
+        xForwardedRemoteIpResolver.maxTrustedIndex.assert().isEqualTo(Int.MAX_VALUE)
+        val serverRequest = MockServerHttpRequest.get("")
+            .header(X_FORWARDED_FOR, "localhost")
+        val serverWebExchange = MockServerWebExchange.from(serverRequest)
         val remoteIp = xForwardedRemoteIpResolver.extractXForwardedHeaderValues(serverWebExchange)
-        assertThat(remoteIp, equalTo(listOf("localhost")))
+        remoteIp.assert().containsExactly("localhost")
     }
 }

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/CoSecServletRequest.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/CoSecServletRequest.kt
@@ -29,6 +29,9 @@ data class CoSecServletRequest(
     override fun getHeader(key: String): String {
         return delegate.getHeader(key).orEmpty()
     }
+    override fun getQuery(key: String): String {
+        return delegate.getParameter(key).orEmpty()
+    }
 
     override fun withAttributes(attributes: Map<String, String>): Request = copy(attributes = attributes)
 

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
@@ -56,6 +56,7 @@ internal class AuthorizationFilterTest {
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
             every { getHeader(AUTHORIZATION_HEADER_KEY) } returns null
+            every { getParameter(AUTHORIZATION_HEADER_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns null
             every { getHeader(HttpHeaders.REFERER) } returns null
             every { setSecurityContext(any()) } returns Unit
@@ -82,6 +83,7 @@ internal class AuthorizationFilterTest {
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
             every { getHeader(AUTHORIZATION_HEADER_KEY) } returns null
+            every { getParameter(AUTHORIZATION_HEADER_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns "ORIGIN"
             every { getHeader(HttpHeaders.REFERER) } returns "REFERER"
             every { setSecurityContext(any()) } returns Unit
@@ -153,6 +155,7 @@ internal class AuthorizationFilterTest {
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
             every { getHeader(AUTHORIZATION_HEADER_KEY) } returns null
+            every { getParameter(AUTHORIZATION_HEADER_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns null
             every { getHeader(HttpHeaders.REFERER) } returns null
             every { setSecurityContext(any()) } returns Unit

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/CoSecServletRequestTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/CoSecServletRequestTest.kt
@@ -16,8 +16,7 @@ package me.ahoo.cosec.servlet
 import io.mockk.every
 import io.mockk.mockk
 import jakarta.servlet.http.HttpServletRequest
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class CoSecServletRequestTest {
@@ -26,6 +25,7 @@ class CoSecServletRequestTest {
         val delegate = mockk<HttpServletRequest> {
             every { getHeader("key") } returns "value"
             every { getHeader("not-exists") } returns null
+            every { getParameter("key") } returns "value"
         }
         val request = CoSecServletRequest(
             delegate = delegate,
@@ -35,19 +35,11 @@ class CoSecServletRequestTest {
             origin = "origin",
             referer = "referer",
         ).withAttributes(emptyMap())
-        assertThat(
-            request.toString(),
-            `is`(
-                "CoSecServletRequest(path='path', method='method', remoteIp='remoteIp', origin='origin', referer='referer')"
-            ),
+        request.toString().assert().isEqualTo(
+            "CoSecServletRequest(path='path', method='method', remoteIp='remoteIp', origin='origin', referer='referer')"
         )
-        assertThat(
-            request.getHeader("key"),
-            `is`("value"),
-        )
-        assertThat(
-            request.getHeader("not-exists"),
-            `is`(""),
-        )
+        request.getHeader("key").assert().isEqualTo("value")
+        request.getQuery("key").assert().isEqualTo("value")
+        request.getHeader("not-exists").assert().isEqualTo("")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ java-jwt = "4.5.0"
 ip2region = "2.7.0"
 justAuth = "1.16.7"
 swagger = "2.2.30"
+# testing
+fluent-assert = "0.1.0"
 hamcrest = "3.0"
 mockk = "1.14.0"
 jmh = "1.37"
@@ -36,6 +38,7 @@ java-jwt = { module = "com.auth0:java-jwt", version.ref = "java-jwt" }
 ip2region = { module = "org.lionsoul:ip2region", version.ref = "ip2region" }
 justAuth = { module = "me.zhyd.oauth:JustAuth", version.ref = "justAuth" }
 swagger = { module = "io.swagger.core.v3:swagger-core-jakarta", version.ref = "swagger" }
+fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }


### PR DESCRIPTION
- Replace Hamcrest assertions with custom assert extensions
- Add checks for query parameters in various test classes
- Update mock setups to include query parameter expectations
- Refactor some tests to use Spring's MockServerHttpRequest and MockServerWebExchange