### PR TITLE
refactor(token): rename asAuthorizeResult to toAuthorizeResult

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,4 +13,5 @@ coverage:
         threshold: 1%
 ignore:
   - "document/.*"
+  - "cosec-api/.*"
   - "cosec-gateway-server/.*"

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/token/TokenVerificationException.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/token/TokenVerificationException.kt
@@ -23,7 +23,7 @@ open class TokenVerificationException : CoSecException {
     constructor(cause: Throwable) : super(cause)
 }
 
-fun TokenVerificationException.asAuthorizeResult(): AuthorizeResult {
+fun TokenVerificationException.toAuthorizeResult(): AuthorizeResult {
     if (this is TokenExpiredException) {
         return AuthorizeResult.TOKEN_EXPIRED
     }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/tenant/SimpleTenantTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/tenant/SimpleTenantTest.kt
@@ -13,23 +13,22 @@
 
 package me.ahoo.cosec.tenant
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class SimpleTenantTest {
     @Test
     fun isDefaultTenant() {
-        assertThat(SimpleTenant.DEFAULT.isDefaultTenant, equalTo(true))
+        SimpleTenant.DEFAULT.isDefaultTenant.assert().isTrue()
     }
 
     @Test
     fun isPlatformTenant() {
-        assertThat(SimpleTenant.PLATFORM.isPlatformTenant, equalTo(true))
+        SimpleTenant.PLATFORM.isPlatformTenant.assert().isTrue()
     }
 
     @Test
     fun isUserTenant() {
-        assertThat(SimpleTenant("userTenantId").isUserTenant, equalTo(true))
+        SimpleTenant("userTenantId").isUserTenant.assert().isTrue()
     }
 }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/token/TokenCompositeAuthenticationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/token/TokenCompositeAuthenticationTest.kt
@@ -21,6 +21,7 @@ import me.ahoo.cosec.api.principal.CoSecPrincipal
 import me.ahoo.cosec.authentication.CompositeAuthentication
 import me.ahoo.cosec.authentication.DefaultAuthenticationProvider
 import me.ahoo.cosec.principal.SimplePrincipal
+import me.ahoo.test.asserts.assert
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
@@ -37,7 +38,7 @@ class TokenCompositeAuthenticationTest {
             every { toToken(any()) } returns compositeToken
         }
         val tokenCompositeAuthentication = TokenCompositeAuthentication(compositeAuthentication, tokenConverter)
-        assertThat(tokenCompositeAuthentication.supportCredentials, `is`(Credentials::class.java))
+        tokenCompositeAuthentication.supportCredentials.assert().isEqualTo(Credentials::class.java)
 
         val credentials = mockk<Credentials>()
         val authentication = mockk<Authentication<Credentials, CoSecPrincipal>> {
@@ -48,7 +49,7 @@ class TokenCompositeAuthenticationTest {
         tokenCompositeAuthentication.authenticateAsToken(credentials)
             .test()
             .consumeNextWith {
-                assertThat(it, `is`(compositeToken))
+                it.assert().isEqualTo(compositeToken)
             }
             .verifyComplete()
     }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/token/TokenVerificationExceptionKtTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/token/TokenVerificationExceptionKtTest.kt
@@ -14,15 +14,14 @@
 package me.ahoo.cosec.token
 
 import me.ahoo.cosec.api.authorization.AuthorizeResult
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class TokenVerificationExceptionKtTest {
 
     @Test
-    fun asAuthorizeResult() {
-        assertThat(TokenVerificationException().asAuthorizeResult().reason, equalTo("Token Invalid"))
-        assertThat(TokenExpiredException().asAuthorizeResult(), sameInstance(AuthorizeResult.TOKEN_EXPIRED))
+    fun toAuthorizeResult() {
+        TokenVerificationException().toAuthorizeResult().reason.assert().isEqualTo("Token Invalid")
+        TokenExpiredException().toAuthorizeResult().assert().isSameAs(AuthorizeResult.TOKEN_EXPIRED)
     }
 }

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
@@ -23,7 +23,7 @@ import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
 import me.ahoo.cosec.token.TokenVerificationException
-import me.ahoo.cosec.token.asAuthorizeResult
+import me.ahoo.cosec.token.toAuthorizeResult
 import me.ahoo.cosec.webflux.ReactiveSecurityContexts.writeSecurityContext
 import me.ahoo.cosec.webflux.ServerWebExchanges.setSecurityContext
 import org.springframework.http.HttpStatus
@@ -75,7 +75,7 @@ abstract class ReactiveSecurityFilter(
                     exchange.response.statusCode = HttpStatus.FORBIDDEN
                 }
                 exchange.response.writeWithAuthorizeResult(
-                    tokenVerificationException?.asAuthorizeResult() ?: authorizeResult,
+                    tokenVerificationException?.toAuthorizeResult() ?: authorizeResult,
                 )
             }.onErrorResume(TooManyRequestsException::class.java) { _ ->
                 exchange.response.statusCode = HttpStatus.TOO_MANY_REQUESTS

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt
@@ -24,7 +24,7 @@ import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
 import me.ahoo.cosec.servlet.ServletRequests.setSecurityContext
 import me.ahoo.cosec.token.TokenVerificationException
-import me.ahoo.cosec.token.asAuthorizeResult
+import me.ahoo.cosec.token.toAuthorizeResult
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 
@@ -64,7 +64,7 @@ abstract class AbstractAuthorizationInterceptor(
                     }
 
                     servletResponse.writeWithAuthorizeResult(
-                        tokenVerificationException?.asAuthorizeResult() ?: it,
+                        tokenVerificationException?.toAuthorizeResult() ?: it,
                     )
                     return@map false
                 }


### PR DESCRIPTION
- Update method name from asAuthorizeResult to toAuthorizeResult in TokenVerificationException
- Update corresponding test cases to use new method name
- Improve test assertions using me.ahoo.test.asserts library
- Update codecov.yml to ignore cosec-api module
