### PR TITLE
ci: add push event to integration test workflow 

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,9 +1,5 @@
 name: Codecov
 on:
-  push:
-    paths-ignore:
-      - 'document/**'
-      - 'cosec-gateway-server/**'
   pull_request:
     paths-ignore:
       - 'document/**'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,9 @@
 name: Codecov
 on:
+  push:
+    paths-ignore:
+      - 'document/**'
+      - 'cosec-gateway-server/**'
   pull_request:
     paths-ignore:
       - 'document/**'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@
 #
 
 name: Integration Test
-on: [ push, pull_request ]
+on: [ pull_request ]
 jobs:
   cosec-core-test:
     name: CoSec Core Test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@
 #
 
 name: Integration Test
-on: [ push, pull_request ]
+on: [  pull_request ]
 jobs:
   cosec-core-test:
     name: CoSec Core Test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@
 #
 
 name: Integration Test
-on: [  pull_request ]
+on: [ pull_request ]
 jobs:
   cosec-core-test:
     name: CoSec Core Test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@
 #
 
 name: Integration Test
-on: [  pull_request ]
+on: [ push, pull_request ]
 jobs:
   cosec-core-test:
     name: CoSec Core Test


### PR DESCRIPTION
- Add push event to the 'on' section of the integration test workflow
- This allows the integration tests to run on push events as well as pull requests