### PR TITLE
ci: ignore document and cosec-gateway-server changes in Codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,9 @@
 name: Codecov
 on:
+  push:
+    paths-ignore:
+      - 'document/**'
+      - 'cosec-gateway-server/**'
   pull_request:
     paths-ignore:
       - 'document/**'


### PR DESCRIPTION
- Add paths-ignore for document and cosec-gateway-server in push event
- Keep existing paths-ignore for pull_request event
