### PR TITLE
refactor(cosec-spring-boot-starter): enhance TokenConverter bean creation

### DIFF
--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/CoSecJwtAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/CoSecJwtAutoConfigurationTest.kt
@@ -49,6 +49,23 @@ class CoSecJwtAutoConfigurationTest {
     }
 
     @Test
+    fun contextLoadsIfNotExistIdGenerator() {
+        contextRunner
+            .withPropertyValues(
+                "${JwtProperties.PREFIX}.secret=FyN0Igd80Gas8stTavArGKOYnS9uLwGA_",
+            )
+            .withUserConfiguration(
+                CoSecJwtAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                AssertionsForInterfaceTypes.assertThat(context)
+                    .hasSingleBean(Algorithm::class.java)
+                    .hasSingleBean(TokenConverter::class.java)
+                    .hasSingleBean(TokenVerifier::class.java)
+            }
+    }
+
+    @Test
     fun contextLoadsWhenDisable() {
         contextRunner
             .withPropertyValues(


### PR DESCRIPTION
- Move TokenConverter bean creation to the main CoSecJwtAutoConfiguration class
- Add conditional logic to use UuidGenerator if no IdGenerator bean is available
- Add test case to verify context loads with default IdGenerator
- Remove redundant TokenConverter bean creation from OnAuthentication class
