### PR TITLE
refactor(request): change origin and referer type to URI

### DIFF
--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/Request.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/Request.kt
@@ -16,6 +16,7 @@ package me.ahoo.cosec.api.context.request
 import me.ahoo.cosec.api.context.Attributes
 import me.ahoo.cosec.api.context.request.AppIdCapable.Companion.APP_ID_KEY
 import me.ahoo.cosec.api.context.request.DeviceIdCapable.Companion.DEVICE_ID_KEY
+import java.net.URI
 
 interface Request : Attributes<Request, String, String>, AppIdCapable, DeviceIdCapable {
 
@@ -30,8 +31,8 @@ interface Request : Attributes<Request, String, String>, AppIdCapable, DeviceIdC
     val path: String
     val method: String
     val remoteIp: String
-    val origin: String
-    val referer: String
+    val origin: URI
+    val referer: URI
     fun getHeader(key: String): String
     fun getQuery(key: String): String
 }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluator.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluator.kt
@@ -19,6 +19,7 @@ import me.ahoo.cosec.api.policy.PolicyEvaluator
 import me.ahoo.cosec.context.SimpleSecurityContext
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
 import me.ahoo.cosec.principal.SimpleTenantPrincipal
+import java.net.URI
 
 object DefaultPolicyEvaluator : PolicyEvaluator {
     override fun evaluate(policy: Policy) {
@@ -55,8 +56,8 @@ data class EvaluateRequest(
     override val path: String = "/policies/test",
     override val method: String = "POST",
     override val remoteIp: String = "127.0.0.1",
-    override val origin: String = "mockOrigin",
-    override val referer: String = "mockReferer",
+    override val origin: URI = URI.create("http://mockOrigin"),
+    override val referer: URI = URI.create("http://mockReferer"),
     override val attributes: Map<String, String> = mapOf(),
     private val headers: Map<String, String> = mapOf(),
     private val queries: Map<String, String> = mapOf(),

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/part/PartExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/part/PartExtractor.kt
@@ -55,8 +55,8 @@ data class DefaultPartExtractor(val part: String) : PartExtractor {
             RequestParts.APP_ID -> request.appId
             RequestParts.DEVICE_ID -> request.deviceId
             RequestParts.REMOTE_IP -> request.remoteIp
-            RequestParts.ORIGIN -> request.origin
-            RequestParts.REFERER -> request.referer
+            RequestParts.ORIGIN -> request.origin.toString()
+            RequestParts.REFERER -> request.referer.toString()
             SecurityContextParts.TENANT_ID -> securityContext.tenant.tenantId
             SecurityContextParts.PRINCIPAL_ID -> securityContext.principal.id
             else -> {

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluatorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/DefaultPolicyEvaluatorTest.kt
@@ -29,6 +29,7 @@ import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import java.net.URI
 
 internal class DefaultPolicyEvaluatorTest {
 
@@ -37,8 +38,8 @@ internal class DefaultPolicyEvaluatorTest {
         var evaluateRequest: Request = EvaluateRequest()
         evaluateRequest.method.assert().isEqualTo("POST")
         evaluateRequest.remoteIp.assert().isEqualTo("127.0.0.1")
-        evaluateRequest.origin.assert().isEqualTo("mockOrigin")
-        evaluateRequest.referer.assert().isEqualTo("mockReferer")
+        evaluateRequest.origin.assert().hasHost("mockOrigin")
+        evaluateRequest.referer.assert().hasHost("mockReferer")
         evaluateRequest.getHeader("key").assert().isEqualTo("")
         evaluateRequest.getQuery("key").assert().isEqualTo("")
         evaluateRequest.attributes.assert().isEmpty()
@@ -52,15 +53,15 @@ internal class DefaultPolicyEvaluatorTest {
             path = "/policies/hi",
             method = "GET",
             remoteIp = "127.0.0.2",
-            origin = "mock",
-            referer = "mock",
+            origin = URI.create("mock"),
+            referer = URI.create("mock"),
             headers = mapOf("key" to "value"),
             queries = mapOf("key" to "value"),
         )
         evaluateRequest.method.assert().isEqualTo("GET")
         evaluateRequest.remoteIp.assert().isEqualTo("127.0.0.2")
-        evaluateRequest.origin.assert().isEqualTo("mock")
-        evaluateRequest.referer.assert().isEqualTo("mock")
+        evaluateRequest.origin.toString().assert().isEqualTo("mock")
+        evaluateRequest.referer.toString().assert().isEqualTo("mock")
         evaluateRequest.getHeader("key").assert().isEqualTo("value")
         evaluateRequest.getQuery("key").assert().isEqualTo("value")
         evaluateRequest.attributes.assert().isEmpty()

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/condition/part/DefaultPartExtractorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/condition/part/DefaultPartExtractorTest.kt
@@ -16,67 +16,67 @@ package me.ahoo.cosec.policy.condition.part
 import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.AppIdCapable
+import me.ahoo.cosec.api.context.request.DeviceIdCapable
 import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.policy.EvaluateRequest
 import me.ahoo.cosec.policy.action.getPathVariables
 import me.ahoo.test.asserts.assert
 import me.ahoo.test.asserts.assertThrownBy
 import org.junit.jupiter.api.Test
+import java.net.URI
 
 class DefaultPartExtractorTest {
 
     @Test
     fun extractRequestPath() {
-        val request: Request = mockk {
-            every { path } returns "path"
-        }
+        val request: Request = EvaluateRequest(path = "path")
         DefaultPartExtractor(RequestParts.PATH).extract(request, mockk()).assert().isEqualTo("path")
     }
 
     @Test
     fun extractRequestMethod() {
-        val request: Request = mockk {
-            every { method } returns "method"
-        }
+        val request: Request = EvaluateRequest(method = "method")
+
         DefaultPartExtractor(RequestParts.METHOD).extract(request, mockk()).assert().isEqualTo("method")
     }
 
     @Test
     fun extractRequestRemoteIp() {
-        val request: Request = mockk {
-            every { remoteIp } returns "remoteIp"
-        }
+        val request: Request = EvaluateRequest(remoteIp = "remoteIp")
         DefaultPartExtractor(RequestParts.REMOTE_IP).extract(request, mockk()).assert().isEqualTo("remoteIp")
     }
 
     @Test
     fun extractRequestAppId() {
-        val request: Request = mockk {
-            every { appId } returns "appId"
-        }
+        val request: Request = EvaluateRequest(
+            headers = mapOf(
+                AppIdCapable.APP_ID_KEY to "appId"
+            )
+        )
         DefaultPartExtractor(RequestParts.APP_ID).extract(request, mockk()).assert().isEqualTo("appId")
     }
 
     @Test
     fun extractRequestDeviceId() {
-        val request: Request = mockk {
-            every { deviceId } returns "deviceId"
-        }
+        val request: Request = EvaluateRequest(
+            headers = mapOf(
+                DeviceIdCapable.DEVICE_ID_KEY to "deviceId"
+            )
+        )
+
         DefaultPartExtractor(RequestParts.DEVICE_ID).extract(request, mockk()).assert().isEqualTo("deviceId")
     }
 
     @Test
     fun extractRequestOrigin() {
-        val request: Request = mockk {
-            every { origin } returns "origin"
-        }
+        val request: Request = EvaluateRequest(origin = URI.create("origin"))
         DefaultPartExtractor(RequestParts.ORIGIN).extract(request, mockk()).assert().isEqualTo("origin")
     }
 
     @Test
     fun extractRequestReferer() {
-        val request: Request = mockk {
-            every { referer } returns "referer"
-        }
+        val request: Request = EvaluateRequest(referer = URI.create("referer"))
         DefaultPartExtractor(RequestParts.REFERER).extract(request, mockk()).assert().isEqualTo("referer")
     }
 

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequest.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequest.kt
@@ -16,14 +16,15 @@ package me.ahoo.cosec.webflux
 import me.ahoo.cosec.Delegated
 import me.ahoo.cosec.api.context.request.Request
 import org.springframework.web.server.ServerWebExchange
+import java.net.URI
 
 data class ReactiveRequest(
     override val delegate: ServerWebExchange,
     override val path: String,
     override val method: String,
     override val remoteIp: String,
-    override val origin: String,
-    override val referer: String,
+    override val origin: URI,
+    override val referer: URI,
     override val attributes: Map<String, String> = mapOf()
 ) : Request,
     Delegated<ServerWebExchange> {

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequestParser.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequestParser.kt
@@ -19,6 +19,7 @@ import me.ahoo.cosec.context.request.RequestAttributesAppender
 import me.ahoo.cosec.context.request.RequestParser
 import org.springframework.http.HttpHeaders
 import org.springframework.web.server.ServerWebExchange
+import java.net.URI
 
 class ReactiveRequestParser(
     private val remoteIpResolver: RemoteIpResolver<ServerWebExchange>,
@@ -31,8 +32,8 @@ class ReactiveRequestParser(
             path = request.request.path.value(),
             method = request.request.method.name(),
             remoteIp = remoteIpResolver.resolve(request),
-            origin = request.request.headers.origin.orEmpty(),
-            referer = request.request.headers.getFirst(HttpHeaders.REFERER).orEmpty(),
+            origin = URI.create(request.request.headers.origin.orEmpty()),
+            referer = URI.create(request.request.headers.getFirst(HttpHeaders.REFERER).orEmpty()),
         )
 
         for (requestAttributesAppender in requestAttributesAppends) {

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestParserTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestParserTest.kt
@@ -30,7 +30,6 @@ internal class ReactiveRequestParserTest {
             .remoteAddress(InetSocketAddress.createUnresolved("localhost", 8080))
             .header(X_FORWARDED_FOR, "localhost")
         val serverWebExchange = MockServerWebExchange.from(serverRequest)
-
         val request = requestParser.parse(serverWebExchange)
         assertThat(request.path, `is`("/path"))
         assertThat(request.method, `is`("GET"))

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestTest.kt
@@ -17,6 +17,7 @@ import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.server.MockServerWebExchange
+import java.net.URI
 
 class ReactiveRequestTest {
     @Test
@@ -31,12 +32,12 @@ class ReactiveRequestTest {
             path = "path",
             method = "method",
             remoteIp = "remoteIp",
-            origin = "origin",
-            referer = "referer",
+            origin = URI.create("http://origin"),
+            referer = URI.create("http://referer"),
         ).withAttributes(emptyMap())
         request.toString().assert()
             .isEqualTo(
-                "ReactiveRequest(path='path', method='method', remoteIp='remoteIp', origin='origin', referer='referer')"
+                "ReactiveRequest(path='path', method='method', remoteIp='remoteIp', origin='http://origin', referer='http://referer')"
             )
         request.appId.assert().isEmpty()
         request.deviceId.assert().isEmpty()

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/CoSecServletRequest.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/CoSecServletRequest.kt
@@ -16,14 +16,15 @@ package me.ahoo.cosec.servlet
 import jakarta.servlet.http.HttpServletRequest
 import me.ahoo.cosec.Delegated
 import me.ahoo.cosec.api.context.request.Request
+import java.net.URI
 
 data class CoSecServletRequest(
     override val delegate: HttpServletRequest,
     override val path: String,
     override val method: String,
     override val remoteIp: String,
-    override val origin: String,
-    override val referer: String,
+    override val origin: URI,
+    override val referer: URI,
     override val attributes: Map<String, String> = mapOf()
 ) : Request, Delegated<HttpServletRequest> {
     override fun getHeader(key: String): String {

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/ServletRequestParser.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/ServletRequestParser.kt
@@ -18,6 +18,7 @@ import me.ahoo.cosec.context.request.RemoteIpResolver
 import me.ahoo.cosec.context.request.RequestAttributesAppender
 import me.ahoo.cosec.context.request.RequestParser
 import org.springframework.http.HttpHeaders
+import java.net.URI
 
 /**
  * ServletRequestParser .
@@ -34,8 +35,8 @@ class ServletRequestParser(
             path = request.servletPath,
             method = request.method,
             remoteIp = remoteIPResolver.resolve(request),
-            origin = request.getHeader(HttpHeaders.ORIGIN).orEmpty(),
-            referer = request.getHeader(HttpHeaders.REFERER).orEmpty(),
+            origin = URI.create(request.getHeader(HttpHeaders.ORIGIN).orEmpty()),
+            referer = URI.create(request.getHeader(HttpHeaders.REFERER).orEmpty()),
         )
         for (requestAttributesAppender in requestAttributesAppends) {
             cosecRequest = requestAttributesAppender.append(cosecRequest)

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/CoSecServletRequestTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/CoSecServletRequestTest.kt
@@ -18,6 +18,7 @@ import io.mockk.mockk
 import jakarta.servlet.http.HttpServletRequest
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
+import java.net.URI
 
 class CoSecServletRequestTest {
     @Test
@@ -32,11 +33,11 @@ class CoSecServletRequestTest {
             path = "path",
             method = "method",
             remoteIp = "remoteIp",
-            origin = "origin",
-            referer = "referer",
+            origin = URI.create("http://origin"),
+            referer = URI.create("http://referer"),
         ).withAttributes(emptyMap())
         request.toString().assert().isEqualTo(
-            "CoSecServletRequest(path='path', method='method', remoteIp='remoteIp', origin='origin', referer='referer')"
+            "CoSecServletRequest(path='path', method='method', remoteIp='remoteIp', origin='http://origin', referer='http://referer')"
         )
         request.getHeader("key").assert().isEqualTo("value")
         request.getQuery("key").assert().isEqualTo("value")


### PR DESCRIPTION
- Update origin and referer properties from String to URI in Request interface
- Modify related classes and tests to use URI for origin and referer
- Adjust PartExtractor to handle URI values for origin and referer
- Update ReactiveRequest and CoSecServletRequest to use URI

