### PR TITLE
feat(condition): add origin host extraction support

### DIFF
--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/part/PartExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/part/PartExtractor.kt
@@ -31,6 +31,7 @@ object RequestParts {
     const val DEVICE_ID = PREFIX + "deviceId"
     const val REMOTE_IP = PREFIX + "remoteIp"
     const val ORIGIN = PREFIX + "origin"
+    const val ORIGIN_HOST = "$ORIGIN.host"
     const val REFERER = PREFIX + "referer"
     const val HEADER_PREFIX = PREFIX + "header."
     const val ATTRIBUTES_PREFIX = PREFIX + "attributes."
@@ -56,6 +57,7 @@ data class DefaultPartExtractor(val part: String) : PartExtractor {
             RequestParts.DEVICE_ID -> request.deviceId
             RequestParts.REMOTE_IP -> request.remoteIp
             RequestParts.ORIGIN -> request.origin.toString()
+            RequestParts.ORIGIN_HOST -> request.origin.host.orEmpty()
             RequestParts.REFERER -> request.referer.toString()
             SecurityContextParts.TENANT_ID -> securityContext.tenant.tenantId
             SecurityContextParts.PRINCIPAL_ID -> securityContext.principal.id

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/condition/part/DefaultPartExtractorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/condition/part/DefaultPartExtractorTest.kt
@@ -70,8 +70,20 @@ class DefaultPartExtractorTest {
 
     @Test
     fun extractRequestOrigin() {
-        val request: Request = EvaluateRequest(origin = URI.create("origin"))
-        DefaultPartExtractor(RequestParts.ORIGIN).extract(request, mockk()).assert().isEqualTo("origin")
+        val request: Request = EvaluateRequest(origin = URI.create("http://origin"))
+        DefaultPartExtractor(RequestParts.ORIGIN).extract(request, mockk()).assert().isEqualTo("http://origin")
+    }
+
+    @Test
+    fun extractRequestOriginHost() {
+        val request: Request = EvaluateRequest(origin = URI.create("http://origin"))
+        DefaultPartExtractor(RequestParts.ORIGIN_HOST).extract(request, mockk()).assert().isEqualTo("origin")
+    }
+
+    @Test
+    fun extractRequestOriginHostNotFound() {
+        val request: Request = EvaluateRequest(origin = URI.create(""))
+        DefaultPartExtractor(RequestParts.ORIGIN_HOST).extract(request, mockk()).assert().isEqualTo("")
     }
 
     @Test

--- a/schema/condition.schema.json
+++ b/schema/condition.schema.json
@@ -70,6 +70,7 @@
         "request.deviceId",
         "request.remoteIp",
         "request.origin",
+        "request.origin.host",
         "request.referer",
         "request.header.",
         "request.header.cosec-app-id",


### PR DESCRIPTION
- Add support for extracting the host from the request origin
- Update schema to include the new 'request.origin.host' condition
- Add unit tests for the new origin host extraction functionality

