### PR TITLE
test: upgrade JUnit to version5.13.0 and add launcher dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,6 +133,7 @@ configure(libraryProjects) {
 
     dependencies {
         api(platform(dependenciesProject))
+        testImplementation(platform(rootProject.libs.junit.bom))
         detektPlugins(platform(dependenciesProject))
         jmh(platform(dependenciesProject))
         implementation("com.google.guava:guava")
@@ -145,6 +146,7 @@ configure(libraryProjects) {
         }
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
         detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
         jmh("org.openjdk.jmh:jmh-core")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ ip2region = "2.7.0"
 justAuth = "1.16.7"
 swagger = "2.2.32"
 # testing
+junit = "5.13.0"
 fluent-assert = "0.1.2"
 hamcrest = "3.0"
 mockk = "1.14.2"
@@ -38,6 +39,7 @@ java-jwt = { module = "com.auth0:java-jwt", version.ref = "java-jwt" }
 ip2region = { module = "org.lionsoul:ip2region", version.ref = "ip2region" }
 justAuth = { module = "me.zhyd.oauth:JustAuth", version.ref = "justAuth" }
 swagger = { module = "io.swagger.core.v3:swagger-core-jakarta", version.ref = "swagger" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
- Update JUnit version to 5.13.0 in gradle/libs.versions.toml
- Add junit-platform-launcher as a testRuntimeOnly dependency in build.gradle.kts
