### PR TITLE
feat(openapi): add Bearer token authentication support

### DIFF
--- a/cosec-dependencies/build.gradle.kts
+++ b/cosec-dependencies/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(platform(libs.cocache.bom))
     api(platform(libs.justAuth))
     api(platform(libs.opentelemetry.instrumentation.bom))
+    api(platform(libs.springdoc.bom))
     api(platform(libs.fluent.assert.bom))
     constraints {
         api(libs.ognl)

--- a/cosec-openapi/src/main/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizer.kt
+++ b/cosec-openapi/src/main/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizer.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.openapi.security
+
+import com.google.common.net.HttpHeaders
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import java.util.function.Consumer
+
+object BearerAuthOpenApiCustomizer : Consumer<OpenAPI> {
+    const val BEARER_AUTH = "bearerAuth"
+    override fun accept(openAPI: OpenAPI) {
+        openAPI.addSecurityItem(SecurityRequirement().addList(BEARER_AUTH))
+        if (openAPI.components == null) {
+            openAPI.components(Components())
+        }
+
+        openAPI.components.addSecuritySchemes(
+            BEARER_AUTH,
+            SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .`in`(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION)
+                .scheme("bearer")
+                .description("Bearer Token")
+                .bearerFormat("JWT")
+        )
+    }
+}

--- a/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/generator/OpenAPIAppPermissionGeneratorTest.kt
+++ b/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/generator/OpenAPIAppPermissionGeneratorTest.kt
@@ -1,11 +1,23 @@
-package me.ahoo.cosec.generator
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.openapi.generator
 
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.Paths
 import io.swagger.v3.oas.models.info.Info
-import me.ahoo.cosec.openapi.generator.OpenAPIAppPermissionGenerator
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*

--- a/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/generator/OpenAPIPolicyGeneratorTest.kt
+++ b/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/generator/OpenAPIPolicyGeneratorTest.kt
@@ -1,10 +1,23 @@
-package me.ahoo.cosec.generator
+
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.openapi.generator
 
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.Paths
-import me.ahoo.cosec.openapi.generator.OpenAPIPolicyGenerator
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test

--- a/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizerTest.kt
+++ b/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizerTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.openapi.security
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.junit.jupiter.api.Test
+
+class BearerAuthOpenApiCustomizerTest {
+    @Test
+    fun customise() {
+        val openAPI = OpenAPI()
+        BearerAuthOpenApiCustomizer.accept(openAPI)
+        openAPI.components.securitySchemes.containsKey(BearerAuthOpenApiCustomizer.BEARER_AUTH)
+    }
+}

--- a/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizerTest.kt
+++ b/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizerTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.cosec.openapi.security
 
+import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import org.junit.jupiter.api.Test
 
@@ -20,6 +21,14 @@ class BearerAuthOpenApiCustomizerTest {
     @Test
     fun customise() {
         val openAPI = OpenAPI()
+        BearerAuthOpenApiCustomizer.accept(openAPI)
+        openAPI.components.securitySchemes.containsKey(BearerAuthOpenApiCustomizer.BEARER_AUTH)
+    }
+
+    @Test
+    fun customiseWithComponents() {
+        val openAPI = OpenAPI()
+        openAPI.components(Components())
         BearerAuthOpenApiCustomizer.accept(openAPI)
         openAPI.components.securitySchemes.containsKey(BearerAuthOpenApiCustomizer.BEARER_AUTH)
     }

--- a/cosec-spring-boot-starter/build.gradle.kts
+++ b/cosec-spring-boot-starter/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     "ip2regionSupportImplementation"(project(":cosec-ip2region"))
     "openapiSupportImplementation"(project(":cosec-openapi"))
     "openapiSupportImplementation"("org.springframework.boot:spring-boot-starter-actuator")
+    "openapiSupportImplementation"("org.springdoc:springdoc-openapi-starter-common")
     api("org.springframework.boot:spring-boot-starter")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
     kapt("org.springframework.boot:spring-boot-autoconfigure-processor")

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/CoSecOpenAPIAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/CoSecOpenAPIAutoConfiguration.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.openapi
+
+import me.ahoo.cosec.openapi.security.BearerAuthOpenApiCustomizer
+import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+@AutoConfiguration
+@ConditionalOnCoSecEnabled
+@ConditionalOnOpenAPIEnabled
+@EnableConfigurationProperties(
+    OpenAPIProperties::class,
+)
+class CoSecOpenAPIAutoConfiguration {
+    @Bean
+    fun bearerAuthOpenApiCustomizer(): OpenApiCustomizer {
+        return OpenApiCustomizer {
+            BearerAuthOpenApiCustomizer.accept(it)
+        }
+    }
+}

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/ConditionalOnOpenAPIEnabled.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/ConditionalOnOpenAPIEnabled.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.spring.boot.starter.openapi
+
+import me.ahoo.cosec.spring.boot.starter.ENABLED_SUFFIX_KEY
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/**
+ * Conditional On CoSec Enabled.
+ *
+ * @author ahoo wang
+ */
+@ConditionalOnProperty(
+    value = [ConditionalOnOpenAPIEnabled.ENABLED_KEY],
+    matchIfMissing = true,
+    havingValue = "true",
+)
+annotation class ConditionalOnOpenAPIEnabled {
+    companion object {
+        const val ENABLED_KEY = OpenAPIProperties.Companion.PREFIX + ENABLED_SUFFIX_KEY
+    }
+}

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/OpenAPIProperties.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/OpenAPIProperties.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.spring.boot.starter.openapi
+
+import me.ahoo.cosec.api.CoSec
+import me.ahoo.cosec.spring.boot.starter.EnabledCapable
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+/**
+ * Authentication Properties .
+ *
+ * @author ahoo wang
+ */
+@ConfigurationProperties(prefix = OpenAPIProperties.PREFIX)
+class OpenAPIProperties(@DefaultValue("true") override var enabled: Boolean = true) : EnabledCapable {
+
+    companion object {
+        const val PREFIX = CoSec.COSEC_PREFIX + "openapi"
+    }
+}

--- a/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -11,3 +11,4 @@ me.ahoo.cosec.spring.boot.starter.jwt.CoSecJwtAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.opentelemetry.CoSecOpenTelemetryAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.ip2region.Ip2RegionAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.actuate.CoSecEndpointAutoConfiguration
+me.ahoo.cosec.spring.boot.starter.openapi.CoSecOpenAPIAutoConfiguration

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/CoSecOpenAPIAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/CoSecOpenAPIAutoConfigurationTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.openapi
+
+import org.assertj.core.api.AssertionsForInterfaceTypes
+import org.junit.jupiter.api.Test
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class CoSecOpenAPIAutoConfigurationTest {
+    private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun contextLoads() {
+        contextRunner
+            .withUserConfiguration(CoSecOpenAPIAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                AssertionsForInterfaceTypes.assertThat(context)
+                    .hasSingleBean(OpenAPIProperties::class.java)
+                    .hasSingleBean(OpenApiCustomizer::class.java)
+            }
+    }
+}

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/CoSecOpenAPIAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/CoSecOpenAPIAutoConfigurationTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.cosec.spring.boot.starter.openapi
 
+import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.AssertionsForInterfaceTypes
 import org.junit.jupiter.api.Test
 import org.springdoc.core.customizers.OpenApiCustomizer
@@ -30,6 +31,8 @@ class CoSecOpenAPIAutoConfigurationTest {
                 AssertionsForInterfaceTypes.assertThat(context)
                     .hasSingleBean(OpenAPIProperties::class.java)
                     .hasSingleBean(OpenApiCustomizer::class.java)
+                val openApiCustomizer = context.getBean(OpenApiCustomizer::class.java)
+                openApiCustomizer.customise(OpenAPI())
             }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ java-jwt = "4.5.0"
 ip2region = "2.7.0"
 justAuth = "1.16.7"
 swagger = "2.2.33"
+springdoc = "2.8.9"
 # testing
 junit = "5.13.1"
 fluent-assert = "0.1.2"
@@ -39,6 +40,7 @@ java-jwt = { module = "com.auth0:java-jwt", version.ref = "java-jwt" }
 ip2region = { module = "org.lionsoul:ip2region", version.ref = "ip2region" }
 justAuth = { module = "me.zhyd.oauth:JustAuth", version.ref = "justAuth" }
 swagger = { module = "io.swagger.core.v3:swagger-core-jakarta", version.ref = "swagger" }
+springdoc-bom = { module = "org.springdoc:springdoc-openapi-bom", version.ref = "springdoc" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }


### PR DESCRIPTION
- Implement BearerAuthOpenApiCustomizer to add Bearer token authentication to OpenAPI
- Create OpenAPIProperties to configure OpenAPI support
- Add CoSecOpenAPIAutoConfiguration to automatically configure OpenAPI
- Include unit tests for new OpenAPI functionality
