### PR TITLE
feat(cosec-spring-boot-starter): conditionally enable CoSecOpenAPIAutoConfiguration

### DIFF
--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/CoSecOpenAPIAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/openapi/CoSecOpenAPIAutoConfiguration.kt
@@ -17,6 +17,7 @@ import me.ahoo.cosec.openapi.security.BearerAuthOpenApiCustomizer
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 
@@ -26,6 +27,7 @@ import org.springframework.context.annotation.Bean
 @EnableConfigurationProperties(
     OpenAPIProperties::class,
 )
+@ConditionalOnClass(value = [OpenApiCustomizer::class])
 class CoSecOpenAPIAutoConfiguration {
     @Bean
     fun bearerAuthOpenApiCustomizer(): OpenApiCustomizer {


### PR DESCRIPTION
- Add ConditionalOnClass annotation to CoSecOpenAPIAutoConfiguration
- This ensures the configuration is only loaded when OpenApiCustomizer is present
- Improves modularity and prevents unnecessary loading in incompatible environments

