### PR TITLE
refactor(cosec-openapi): customize bearer authentication scheme

### DIFF
--- a/cosec-openapi/src/main/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizer.kt
+++ b/cosec-openapi/src/main/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizer.kt
@@ -17,22 +17,23 @@ import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import me.ahoo.cosec.api.CoSec
 import java.util.function.Consumer
 
 object BearerAuthOpenApiCustomizer : Consumer<OpenAPI> {
-    const val BEARER_AUTH = "bearerAuth"
+    const val BEARER_AUTH_NAME = CoSec.COSEC_PREFIX + "BearerAuth"
+    const val BEARER_SCHEME = "bearer"
     override fun accept(openAPI: OpenAPI) {
-        openAPI.addSecurityItem(SecurityRequirement().addList(BEARER_AUTH))
+        openAPI.addSecurityItem(SecurityRequirement().addList(BEARER_AUTH_NAME))
         if (openAPI.components == null) {
             openAPI.components(Components())
         }
 
         openAPI.components.addSecuritySchemes(
-            BEARER_AUTH,
+            BEARER_AUTH_NAME,
             SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .description("Bearer Token")
+                .scheme(BEARER_SCHEME)
         )
     }
 }

--- a/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizerTest.kt
+++ b/cosec-openapi/src/test/kotlin/me/ahoo/cosec/openapi/security/BearerAuthOpenApiCustomizerTest.kt
@@ -15,6 +15,8 @@ package me.ahoo.cosec.openapi.security
 
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityScheme
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class BearerAuthOpenApiCustomizerTest {
@@ -22,7 +24,10 @@ class BearerAuthOpenApiCustomizerTest {
     fun customise() {
         val openAPI = OpenAPI()
         BearerAuthOpenApiCustomizer.accept(openAPI)
-        openAPI.components.securitySchemes.containsKey(BearerAuthOpenApiCustomizer.BEARER_AUTH)
+        openAPI.components.securitySchemes.containsKey(BearerAuthOpenApiCustomizer.BEARER_AUTH_NAME)
+        val bearerAuthSecuritySchema = openAPI.components.securitySchemes[BearerAuthOpenApiCustomizer.BEARER_AUTH_NAME]!!
+        bearerAuthSecuritySchema.type.assert().isEqualTo(SecurityScheme.Type.HTTP)
+        bearerAuthSecuritySchema.scheme.assert().isEqualTo(BearerAuthOpenApiCustomizer.BEARER_SCHEME)
     }
 
     @Test
@@ -30,6 +35,6 @@ class BearerAuthOpenApiCustomizerTest {
         val openAPI = OpenAPI()
         openAPI.components(Components())
         BearerAuthOpenApiCustomizer.accept(openAPI)
-        openAPI.components.securitySchemes.containsKey(BearerAuthOpenApiCustomizer.BEARER_AUTH)
+        openAPI.components.securitySchemes.containsKey(BearerAuthOpenApiCustomizer.BEARER_AUTH_NAME)
     }
 }


### PR DESCRIPTION
- Rename BEARER_AUTH to BEARER_AUTH_NAME with CoSec prefix
- Add BEARER_SCHEME constant for scheme name
- Update OpenAPI customization to use new constants
- Add unit tests to verify correct customization
