### PR TITLE
build(gradle): move Detekt configuration to root project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,16 @@ allprojects {
         mavenLocal()
         mavenCentral()
     }
+    apply<DetektPlugin>()
+    configure<DetektExtension> {
+        config.setFrom(files("${rootProject.rootDir}/config/detekt/detekt.yml"))
+        buildUponDefaultConfig = true
+        autoCorrect = true
+    }
+    dependencies {
+        detektPlugins(dependenciesProject)
+        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
+    }
     tasks.withType<Jar> {
         manifest {
             attributes["Implementation-Title"] = project.name
@@ -60,12 +70,6 @@ configure(bomProjects) {
 }
 
 configure(libraryProjects) {
-    apply<DetektPlugin>()
-    configure<DetektExtension> {
-        config.setFrom(files("${rootProject.rootDir}/config/detekt/detekt.yml"))
-        buildUponDefaultConfig = true
-        autoCorrect = true
-    }
     apply<DokkaPlugin>()
     apply<JacocoPlugin>()
     apply<JavaLibraryPlugin>()
@@ -134,7 +138,6 @@ configure(libraryProjects) {
     dependencies {
         api(platform(dependenciesProject))
         testImplementation(platform(rootProject.libs.junit.bom))
-        detektPlugins(platform(dependenciesProject))
         jmh(platform(dependenciesProject))
         implementation("com.google.guava:guava")
         implementation("org.slf4j:slf4j-api")
@@ -148,7 +151,6 @@ configure(libraryProjects) {
         testImplementation("org.junit.jupiter:junit-jupiter-params")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
         jmh("org.openjdk.jmh:jmh-core")
         jmh("org.openjdk.jmh:jmh-generator-annprocess")
     }


### PR DESCRIPTION
- Apply DetektPlugin and configure DetektExtension in the root project
- Remove DetektPlugin application and configuration from library projects
- Update dependencies to include detektPlugins only in the root project
