### PR TITLE
feat(api): add request id capability and set it in response header

### DIFF
--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/Request.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/Request.kt
@@ -16,9 +16,10 @@ package me.ahoo.cosec.api.context.request
 import me.ahoo.cosec.api.context.Attributes
 import me.ahoo.cosec.api.context.request.AppIdCapable.Companion.APP_ID_KEY
 import me.ahoo.cosec.api.context.request.DeviceIdCapable.Companion.DEVICE_ID_KEY
+import me.ahoo.cosec.api.context.request.RequestIdCapable.Companion.REQUEST_ID_KEY
 import java.net.URI
 
-interface Request : Attributes<Request, String, String>, AppIdCapable, DeviceIdCapable {
+interface Request : Attributes<Request, String, String>, AppIdCapable, DeviceIdCapable, RequestIdCapable {
 
     override val appId: String
         get() {
@@ -27,6 +28,10 @@ interface Request : Attributes<Request, String, String>, AppIdCapable, DeviceIdC
     override val deviceId: String
         get() {
             return getHeader(DEVICE_ID_KEY).ifBlank { getQuery(DEVICE_ID_KEY) }
+        }
+    override val requestId: String
+        get() {
+            return getHeader(REQUEST_ID_KEY)
         }
     val path: String
     val method: String

--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/RequestIdCapable.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/context/request/RequestIdCapable.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.api.context.request
+
+interface RequestIdCapable {
+    companion object {
+        const val REQUEST_ID_KEY = "CoSec-Request-Id"
+    }
+
+    val requestId: String
+}

--- a/cosec-gateway/src/test/kotlin/me/ahoo/cosec/gateway/AuthorizationGatewayFilterTest.kt
+++ b/cosec-gateway/src/test/kotlin/me/ahoo/cosec/gateway/AuthorizationGatewayFilterTest.kt
@@ -20,6 +20,7 @@ import io.mockk.runs
 import io.mockk.verify
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.jwt.InjectSecurityContextParser
 import me.ahoo.cosec.webflux.ReactiveRemoteIpResolver
@@ -50,6 +51,8 @@ class AuthorizationGatewayFilterTest {
         )
         assertThat(filter.order, equalTo(Ordered.HIGHEST_PRECEDENCE + 10))
         val exchange = mockk<ServerWebExchange> {
+            every { request.headers.getFirst(RequestIdCapable.REQUEST_ID_KEY) } returns null
+            every { response.headers.set(RequestIdCapable.REQUEST_ID_KEY, any()) } returns Unit
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.headers.origin } returns "origin"

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
@@ -16,6 +16,7 @@ package me.ahoo.cosec.webflux
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.request.RequestIdCapable.Companion.REQUEST_ID_KEY
 import me.ahoo.cosec.context.RequestSecurityContexts.setRequest
 import me.ahoo.cosec.context.SecurityContextParser
 import me.ahoo.cosec.context.SimpleSecurityContext
@@ -59,6 +60,7 @@ abstract class ReactiveSecurityFilter(
         }
         securityContext.setRequest(request)
         exchange.setSecurityContext(securityContext)
+        exchange.response.headers.set(REQUEST_ID_KEY, request.requestId)
         return authorization.authorize(request, securityContext)
             .flatMap { authorizeResult ->
                 if (authorizeResult.authorized) {

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
@@ -21,6 +21,7 @@ import io.mockk.runs
 import io.mockk.verify
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.context.SecurityContextParser
 import me.ahoo.cosec.jwt.InjectSecurityContextParser
@@ -64,6 +65,8 @@ internal class ReactiveAuthorizationFilterTest {
         )
         assertThat(filter.order, equalTo(Ordered.HIGHEST_PRECEDENCE + 10))
         val exchange = mockk<ServerWebExchange> {
+            every { request.headers.getFirst(RequestIdCapable.REQUEST_ID_KEY) } returns null
+            every { response.headers.set(RequestIdCapable.REQUEST_ID_KEY, any()) } returns Unit
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.headers.origin } returns "origin"
@@ -103,6 +106,8 @@ internal class ReactiveAuthorizationFilterTest {
             authorization,
         )
         val exchange = mockk<ServerWebExchange> {
+            every { request.headers.getFirst(RequestIdCapable.REQUEST_ID_KEY) } returns null
+            every { response.headers.set(RequestIdCapable.REQUEST_ID_KEY, any()) } returns Unit
             every { request.headers.origin } returns "origin"
             every { request.headers.getFirst(HttpHeaders.REFERER) } returns "REFERER"
             every { request.path.value() } returns "/path"
@@ -143,6 +148,8 @@ internal class ReactiveAuthorizationFilterTest {
             authorization,
         )
         val exchange = mockk<ServerWebExchange> {
+            every { request.headers.getFirst(RequestIdCapable.REQUEST_ID_KEY) } returns null
+            every { response.headers.set(RequestIdCapable.REQUEST_ID_KEY, any()) } returns Unit
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.headers.origin } returns "origin"
@@ -187,6 +194,8 @@ internal class ReactiveAuthorizationFilterTest {
         val tokenHeader =
             Jwts.TOKEN_PREFIX + accessToken
         val exchange = mockk<ServerWebExchange> {
+            every { request.headers.getFirst(RequestIdCapable.REQUEST_ID_KEY) } returns null
+            every { response.headers.set(RequestIdCapable.REQUEST_ID_KEY, any()) } returns Unit
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns tokenHeader
             every { request.headers.origin } returns "origin"
             every { request.headers.getFirst(HttpHeaders.REFERER) } returns "REFERER"
@@ -195,6 +204,7 @@ internal class ReactiveAuthorizationFilterTest {
             every { request.remoteAddress?.hostName } returns "hostName"
             every { response.setStatusCode(HttpStatus.FORBIDDEN) } returns true
             every { response.headers.contentType = MediaType.APPLICATION_JSON } returns Unit
+            every { response.headers.set(RequestIdCapable.REQUEST_ID_KEY, any()) } returns Unit
             every { response.bufferFactory().wrap(any() as ByteArray) } returns mockk()
             every { response.writeWith(any()) } returns Mono.empty()
             every { setSecurityContext(any()) } just runs
@@ -226,6 +236,8 @@ internal class ReactiveAuthorizationFilterTest {
             authorization,
         )
         val exchange = mockk<ServerWebExchange> {
+            every { request.headers.getFirst(RequestIdCapable.REQUEST_ID_KEY) } returns null
+            every { response.headers.set(RequestIdCapable.REQUEST_ID_KEY, any()) } returns Unit
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.headers.origin } returns "origin"

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt
@@ -16,6 +16,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.request.RequestIdCapable.Companion.REQUEST_ID_KEY
 import me.ahoo.cosec.context.RequestSecurityContexts.setRequest
 import me.ahoo.cosec.context.SecurityContextHolder
 import me.ahoo.cosec.context.SecurityContextParser
@@ -54,6 +55,7 @@ abstract class AbstractAuthorizationInterceptor(
         securityContext.setRequest(request)
         SecurityContextHolder.setContext(securityContext)
         servletRequest.setSecurityContext(securityContext)
+        servletResponse.addHeader(REQUEST_ID_KEY, request.requestId)
         return authorization.authorize(request, securityContext)
             .map {
                 if (!it.authorized) {

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt
@@ -55,7 +55,7 @@ abstract class AbstractAuthorizationInterceptor(
         securityContext.setRequest(request)
         SecurityContextHolder.setContext(securityContext)
         servletRequest.setSecurityContext(securityContext)
-        servletResponse.addHeader(REQUEST_ID_KEY, request.requestId)
+        servletResponse.setHeader(REQUEST_ID_KEY, request.requestId)
         return authorization.authorize(request, securityContext)
             .map {
                 if (!it.authorized) {

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
@@ -23,6 +23,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.context.SecurityContextHolder
 import me.ahoo.cosec.context.SecurityContextParser
@@ -55,16 +56,20 @@ internal class AuthorizationFilterTest {
             every { servletPath } returns "/path"
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
+            every { getHeader(RequestIdCapable.REQUEST_ID_KEY) } returns null
             every { getHeader(AUTHORIZATION_HEADER_KEY) } returns null
             every { getParameter(AUTHORIZATION_HEADER_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns null
             every { getHeader(HttpHeaders.REFERER) } returns null
             every { setSecurityContext(any()) } returns Unit
         }
+        val servletResponse = mockk<HttpServletResponse> {
+            every { setHeader(RequestIdCapable.REQUEST_ID_KEY, any()) } just runs
+        }
         val filterChain = mockk<FilterChain> {
             every { doFilter(servletRequest, any()) } returns Unit
         }
-        filter.doFilter(servletRequest, mockk<HttpServletResponse>(), filterChain)
+        filter.doFilter(servletRequest, servletResponse, filterChain)
         assertThat(SecurityContextHolder.requiredContext.principal, equalTo(SimpleTenantPrincipal.ANONYMOUS))
     }
 
@@ -82,6 +87,7 @@ internal class AuthorizationFilterTest {
             every { servletPath } returns "/path"
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
+            every { getHeader(RequestIdCapable.REQUEST_ID_KEY) } returns null
             every { getHeader(AUTHORIZATION_HEADER_KEY) } returns null
             every { getParameter(AUTHORIZATION_HEADER_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns "ORIGIN"
@@ -89,6 +95,7 @@ internal class AuthorizationFilterTest {
             every { setSecurityContext(any()) } returns Unit
         }
         val servletResponse = mockk<HttpServletResponse> {
+            every { setHeader(RequestIdCapable.REQUEST_ID_KEY, any()) } just runs
             every { contentType = MediaType.APPLICATION_JSON_VALUE } just runs
             every { status = HttpStatus.UNAUTHORIZED.value() } returns Unit
             every { outputStream.write(any() as ByteArray) } returns Unit
@@ -118,11 +125,13 @@ internal class AuthorizationFilterTest {
             every { servletPath } returns "/path"
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
+            every { getHeader(RequestIdCapable.REQUEST_ID_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns "ORIGIN"
             every { getHeader(HttpHeaders.REFERER) } returns "REFERER"
             every { setSecurityContext(any()) } returns Unit
         }
         val servletResponse = mockk<HttpServletResponse> {
+            every { setHeader(RequestIdCapable.REQUEST_ID_KEY, any()) } just runs
             every { contentType = MediaType.APPLICATION_JSON_VALUE } just runs
             every { status = HttpStatus.UNAUTHORIZED.value() } returns Unit
             every { outputStream.write(any() as ByteArray) } returns Unit
@@ -154,6 +163,7 @@ internal class AuthorizationFilterTest {
             every { servletPath } returns "/path"
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
+            every { getHeader(RequestIdCapable.REQUEST_ID_KEY) } returns null
             every { getHeader(AUTHORIZATION_HEADER_KEY) } returns null
             every { getParameter(AUTHORIZATION_HEADER_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns null
@@ -161,6 +171,7 @@ internal class AuthorizationFilterTest {
             every { setSecurityContext(any()) } returns Unit
         }
         val servletResponse = mockk<HttpServletResponse> {
+            every { setHeader(RequestIdCapable.REQUEST_ID_KEY, any()) } just runs
             every { contentType = MediaType.APPLICATION_JSON_VALUE } just runs
             every { status = HttpStatus.TOO_MANY_REQUESTS.value() } returns Unit
             every { outputStream.write(any() as ByteArray) } returns Unit

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilterTest.kt
@@ -17,6 +17,7 @@ import io.mockk.every
 import io.mockk.mockk
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
+import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.context.SecurityContextHolder
 import me.ahoo.cosec.jwt.InjectSecurityContextParser
@@ -37,6 +38,7 @@ internal class InjectSecurityContextFilterTest {
             every { servletPath } returns "/path"
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
+            every { getHeader(RequestIdCapable.REQUEST_ID_KEY) } returns null
             every { getHeader(AUTHORIZATION_HEADER_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns null
             every { getHeader(HttpHeaders.REFERER) } returns null
@@ -57,6 +59,7 @@ internal class InjectSecurityContextFilterTest {
             every { servletPath } returns "/path"
             every { method } returns "GET"
             every { remoteHost } returns "remoteHost"
+            every { getHeader(RequestIdCapable.REQUEST_ID_KEY) } returns null
             every { getHeader(AUTHORIZATION_HEADER_KEY) } returns null
             every { getHeader(HttpHeaders.ORIGIN) } returns null
             every { getHeader(HttpHeaders.REFERER) } returns null


### PR DESCRIPTION
- Add RequestIdCapable interface to Request
- Set request id in response header in AbstractAuthorizationInterceptor and ReactiveSecurityFilter
- Implement requestId getter in Request interface

