### PR TITLE
feat(opentelemetry): add request ID attribute to spans

### DIFF
--- a/cosec-opentelemetry/src/main/kotlin/me/ahoo/cosec/opentelemetry/CoSecInstrumenter.kt
+++ b/cosec-opentelemetry/src/main/kotlin/me/ahoo/cosec/opentelemetry/CoSecInstrumenter.kt
@@ -57,10 +57,11 @@ object CoSecAttributesExtractor : AttributesExtractor<SecurityContext, Authorize
     private val USER_ROLES_ATTRIBUTE_KEY = stringArrayKey("user.roles")
     private const val COSEC_TENANT_ID_KEY = CoSec.COSEC_PREFIX + "tenant_id"
     private const val COSEC_APP_ID_KEY = CoSec.COSEC_PREFIX + "app_id"
+    private const val COSEC_REQUEST_ID_KEY = CoSec.COSEC_PREFIX + "request_id"
     private val COSEC_TENANT_ID_ATTRIBUTE_KEY = stringKey(COSEC_TENANT_ID_KEY)
     private val COSEC_APP_ID_ATTRIBUTE_KEY = stringKey(COSEC_APP_ID_KEY)
     private val COSEC_DEVICE_ID_ATTRIBUTE_KEY = stringKey("device.id")
-
+    private val COSEC_REQUEST_ID_ATTRIBUTE_KEY = stringKey(COSEC_REQUEST_ID_KEY)
     private const val COSEC_POLICY_KEY = CoSec.COSEC_PREFIX + PolicyCapable.POLICY_KEY
     private val COSEC_POLICY_ATTRIBUTE_KEY = stringArrayKey(COSEC_POLICY_KEY)
 
@@ -106,6 +107,10 @@ object CoSecAttributesExtractor : AttributesExtractor<SecurityContext, Authorize
             val deviceId = cosecRequest.deviceId
             if (deviceId.isNotBlank()) {
                 attributes.put(COSEC_DEVICE_ID_ATTRIBUTE_KEY, deviceId)
+            }
+            val requestId = cosecRequest.requestId
+            if (requestId.isNotBlank()) {
+                attributes.put(COSEC_REQUEST_ID_ATTRIBUTE_KEY, requestId)
             }
         }
         val securityContext = request

--- a/cosec-opentelemetry/src/test/kotlin/me/ahoo/cosec/opentelemetry/CoSecAttributesExtractorTest.kt
+++ b/cosec-opentelemetry/src/test/kotlin/me/ahoo/cosec/opentelemetry/CoSecAttributesExtractorTest.kt
@@ -53,6 +53,7 @@ class CoSecAttributesExtractorTest {
         val request = mockk<Request> {
             every { appId } returns "appId"
             every { deviceId } returns "deviceId"
+            every { requestId } returns "requestId"
         }
         val verifyContext = mockk<PolicyVerifyContext> {
             every { policy.id } returns "policyId"
@@ -84,6 +85,7 @@ class CoSecAttributesExtractorTest {
         val request = mockk<Request> {
             every { appId } returns "appId"
             every { deviceId } returns "deviceId"
+            every { requestId } returns "requestId"
         }
         val verifyContext = mockk<RoleVerifyContext> {
             every { roleId } returns "roleId"
@@ -110,6 +112,7 @@ class CoSecAttributesExtractorTest {
         val request = mockk<Request> {
             every { appId } returns ""
             every { deviceId } returns ""
+            every { requestId } returns ""
         }
         val securityContext = SimpleSecurityContext.anonymous()
         securityContext.setRequest(request)

--- a/cosec-opentelemetry/src/test/kotlin/me/ahoo/cosec/opentelemetry/TracingAuthorizationTest.kt
+++ b/cosec-opentelemetry/src/test/kotlin/me/ahoo/cosec/opentelemetry/TracingAuthorizationTest.kt
@@ -119,6 +119,7 @@ class TracingAuthorizationTest {
         val request = mockk<Request> {
             every { appId } returns "appId"
             every { deviceId } returns "deviceId"
+            every { requestId } returns "requestId"
         }
         val verifyContext = mockk<RoleVerifyContext> {
             every { roleId } returns "roleId"


### PR DESCRIPTION
- Add COSEC_REQUEST_ID_KEY and COSEC_REQUEST_ID_ATTRIBUTE_KEY constants
- Include request ID in span attributes if available
- Update test to mock and verify request ID

