### PR TITLE
feat(authorization): enhance ReactiveRequestParser with idGenerator 

### DIFF
--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecRequestParserAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecRequestParserAutoConfiguration.kt
@@ -21,6 +21,8 @@ import me.ahoo.cosec.servlet.ServletXForwardedRemoteIpResolver
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
 import me.ahoo.cosec.webflux.ReactiveRequestParser
 import me.ahoo.cosec.webflux.ReactiveXForwardedRemoteIpResolver
+import me.ahoo.cosid.IdGenerator
+import me.ahoo.cosid.jvm.UuidGenerator
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -79,9 +81,15 @@ class CoSecRequestParserAutoConfiguration {
         @ConditionalOnMissingBean(name = [REACTIVE_REQUEST_PARSER_BEAN_NAME])
         fun reactiveRequestParser(
             reactiveRemoteIpResolver: RemoteIpResolver<ServerWebExchange>,
+            idGeneratorObjectProvider: ObjectProvider<IdGenerator>,
             requestAttributesAppenderObjectProvider: ObjectProvider<RequestAttributesAppender>
         ): RequestParser<ServerWebExchange> {
-            return ReactiveRequestParser(reactiveRemoteIpResolver, requestAttributesAppenderObjectProvider.toList())
+            val idGenerator = idGeneratorObjectProvider.getIfAvailable { UuidGenerator.INSTANCE }
+            return ReactiveRequestParser(
+                remoteIpResolver = reactiveRemoteIpResolver,
+                idGenerator = idGenerator,
+                requestAttributesAppends = requestAttributesAppenderObjectProvider.toList()
+            )
         }
     }
 }

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequest.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequest.kt
@@ -25,6 +25,7 @@ data class ReactiveRequest(
     override val remoteIp: String,
     override val origin: URI,
     override val referer: URI,
+    override val requestId: String,
     override val attributes: Map<String, String> = mapOf()
 ) : Request,
     Delegated<ServerWebExchange> {

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveInjectSecurityContextWebFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveInjectSecurityContextWebFilterTest.kt
@@ -18,6 +18,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.jwt.InjectSecurityContextParser
 import me.ahoo.cosec.webflux.ServerWebExchanges.setSecurityContext
@@ -43,6 +44,7 @@ internal class ReactiveInjectSecurityContextWebFilterTest {
 
         assertThat(filter.order, equalTo(Ordered.HIGHEST_PRECEDENCE + 10))
         val exchange = mockk<ServerWebExchange> {
+            every { request.headers.getFirst(RequestIdCapable.REQUEST_ID_KEY) } returns null
             every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
             every { request.path.value() } returns "/path"
             every { request.method.name() } returns "GET"

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestTest.kt
@@ -34,6 +34,7 @@ class ReactiveRequestTest {
             remoteIp = "remoteIp",
             origin = URI.create("http://origin"),
             referer = URI.create("http://referer"),
+            requestId = "requestId",
         ).withAttributes(emptyMap())
         request.toString().assert()
             .isEqualTo(


### PR DESCRIPTION
- Add idGenerator parameter to ReactiveRequestParser
- Use UuidGenerator as default idGenerator implementation
- Inject idGenerator through ObjectProvider