### PR TITLE
feat(webflux): add request id header to authorized request

### DIFF
--- a/cosec-gateway/build.gradle.kts
+++ b/cosec-gateway/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     implementation(project(":cosec-webflux"))
     implementation("org.springframework.cloud:spring-cloud-gateway-server")
+    testImplementation("org.springframework:spring-test")
 }

--- a/cosec-gateway/src/test/kotlin/me/ahoo/cosec/gateway/AuthorizationGatewayFilterTest.kt
+++ b/cosec-gateway/src/test/kotlin/me/ahoo/cosec/gateway/AuthorizationGatewayFilterTest.kt
@@ -14,28 +14,26 @@
 package me.ahoo.cosec.gateway
 
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.verify
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.api.context.request.RequestIdCapable
-import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.jwt.InjectSecurityContextParser
 import me.ahoo.cosec.webflux.ReactiveRemoteIpResolver
 import me.ahoo.cosec.webflux.ReactiveRequestParser
-import me.ahoo.cosec.webflux.ServerWebExchanges.setSecurityContext
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.cosec.webflux.ServerWebExchanges.getSecurityContext
+import me.ahoo.test.asserts.assert
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.springframework.cloud.gateway.filter.GatewayFilterChain
 import org.springframework.core.Ordered
 import org.springframework.http.HttpHeaders
-import org.springframework.web.server.ServerWebExchange
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
-import java.net.InetSocketAddress
 
 class AuthorizationGatewayFilterTest {
 
@@ -50,31 +48,18 @@ class AuthorizationGatewayFilterTest {
             authorization,
         )
         assertThat(filter.order, equalTo(Ordered.HIGHEST_PRECEDENCE + 10))
-        val exchange = mockk<ServerWebExchange> {
-            every { request.headers.getFirst(RequestIdCapable.REQUEST_ID_KEY) } returns null
-            every { response.headers.set(RequestIdCapable.REQUEST_ID_KEY, any()) } returns Unit
-            every { request.headers.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
-            every { request.queryParams.getFirst(AUTHORIZATION_HEADER_KEY) } returns null
-            every { request.headers.origin } returns "origin"
-            every { request.headers.getFirst(HttpHeaders.REFERER) } returns "REFERER"
-            every { request.path.value() } returns "/path"
-            every { request.method.name() } returns "GET"
-            every { request.remoteAddress } returns InetSocketAddress("hostname", 0)
-            every { setSecurityContext(any()) } just runs
-            every {
-                mutate()
-                    .principal(any())
-                    .build()
-            } returns this
+        val serverRequest = MockServerHttpRequest.get("/path")
+            .header(HttpHeaders.ORIGIN, "origin")
+            .build()
+        val serverExchange = MockServerWebExchange.builder(serverRequest).build()
+        val filterChain = GatewayFilterChain {
+            it.getSecurityContext().assert().isNotNull()
+            it.request.headers.contains(RequestIdCapable.REQUEST_ID_KEY).assert().isTrue()
+            Mono.empty()
         }
-        val filterChain = mockk<GatewayFilterChain> {
-            every { filter(exchange) } returns Mono.empty()
-        }
-        filter.filter(exchange, filterChain).block()
+        filter.filter(serverExchange, filterChain).block()
         verify {
             authorization.authorize(any(), any())
-            exchange.setSecurityContext(any())
-            filterChain.filter(exchange)
         }
     }
 }

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
@@ -64,7 +64,11 @@ abstract class ReactiveSecurityFilter(
         return authorization.authorize(request, securityContext)
             .flatMap { authorizeResult ->
                 if (authorizeResult.authorized) {
+                    val request = exchange.request.mutate()
+                        .header(REQUEST_ID_KEY, request.requestId)
+                        .build()
                     exchange.mutate()
+                        .request(request)
                         .principal(securityContext.principal.toMono())
                         .build().let {
                             return@flatMap chain(it).writeSecurityContext(securityContext)


### PR DESCRIPTION
- Update the ReactiveSecurityFilter to include the request ID header
- Enhance tracing and debugging capabilities for authorized requests

