### PR TITLE
refactor(webflux): remove request ID header duplication

### DIFF
--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilter.kt
@@ -32,8 +32,8 @@ class ReactiveAuthorizationFilter(
     authorization: Authorization
 ) : WebFilter, Ordered, ReactiveSecurityFilter(securityContextParser, requestParser, authorization) {
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
-        return filterInternal(exchange) {
-            chain.filter(it)
+        return filterInternal(exchange) { serverExchange, request ->
+            chain.filter(serverExchange)
         }
     }
 

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
@@ -75,7 +75,7 @@ internal class ReactiveAuthorizationFilterTest {
         val serverExchange = MockServerWebExchange.builder(serverRequest).build()
         val filterChain = WebFilterChain {
             it.getSecurityContext().assert().isNotNull()
-            it.request.headers.contains(RequestIdCapable.REQUEST_ID_KEY).assert().isTrue()
+            it.request.headers.contains(RequestIdCapable.REQUEST_ID_KEY).assert().isFalse()
             Mono.empty()
         }
         filter.filter(serverExchange, filterChain).block()


### PR DESCRIPTION
- Remove duplicate REQUEST_ID_KEY header in AuthorizationGatewayFilter
- Update ReactiveAuthorizationFilter to use the correct server exchange
- Adjust unit test to reflect the removal of REQUEST_ID_KEY header
- Simplify filterInternal function in ReactiveSecurityFilter

