### PR TITLE
feat(webflux): add HttpHeadersGuard and update request ID setting

### DIFF
--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/HttpHeadersGuard.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/HttpHeadersGuard.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.webflux
+
+import org.springframework.http.HttpHeaders
+
+fun HttpHeaders.trySet(key: String, value: String): Boolean {
+    try {
+        set(key, value)
+        return true
+    } catch (_: UnsupportedOperationException) {
+        return false
+    }
+}

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
@@ -61,7 +61,7 @@ abstract class ReactiveSecurityFilter(
         }
         securityContext.setRequest(request)
         exchange.setSecurityContext(securityContext)
-        exchange.response.headers.set(REQUEST_ID_KEY, request.requestId)
+        exchange.response.headers.trySet(REQUEST_ID_KEY, request.requestId)
         return authorization.authorize(request, securityContext)
             .flatMap { authorizeResult ->
                 if (authorizeResult.authorized) {

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/HttpHeadersGuardTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/HttpHeadersGuardTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.webflux
+
+import me.ahoo.cosec.api.context.request.RequestIdCapable
+import me.ahoo.cosid.jvm.UuidGenerator
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+
+class HttpHeadersGuardTest {
+    @Test
+    fun trySet() {
+        val httpHeaders = HttpHeaders()
+        val value = UuidGenerator.INSTANCE.generateAsString()
+        httpHeaders.trySet(RequestIdCapable.REQUEST_ID_KEY, value).assert().isTrue()
+        httpHeaders.getFirst(RequestIdCapable.REQUEST_ID_KEY).assert().isEqualTo(value)
+    }
+
+    @Test
+    fun trySetIfReadOnly() {
+        val httpHeaders = HttpHeaders()
+        val value = UuidGenerator.INSTANCE.generateAsString()
+        val readOnlyHttpHeaders = HttpHeaders.readOnlyHttpHeaders(httpHeaders)
+        readOnlyHttpHeaders.trySet(RequestIdCapable.REQUEST_ID_KEY, value).assert().isFalse()
+        readOnlyHttpHeaders.getFirst(RequestIdCapable.REQUEST_ID_KEY).assert().isNull()
+    }
+}


### PR DESCRIPTION
- Add HttpHeadersGuard with trySet method to handle read-only headers
- Update ReactiveSecurityFilter to use trySet for request ID
- Add unit tests for HttpHeadersGuard functionality

