### PR TITLE
build(ci): update Sonatype publishing credentials and API endpoint

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Publish package
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
           SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -240,8 +240,9 @@ configure(publishProjects) {
 nexusPublishing {
     this.repositories {
         sonatype {
-            username.set(System.getenv("MAVEN_USERNAME"))
-            password.set(System.getenv("MAVEN_PASSWORD"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            username.set(System.getenv("SONATYPE_USERNAME"))
+            password.set(System.getenv("SONATYPE_PASSWORD"))
         }
     }
 }


### PR DESCRIPTION
- Update nexusPublishing block in build.gradle.kts with new API endpoint and credentials
- Update GitHub Actions workflow to use new SONATYPE_USERNAME and SONATYPE_PASSWORD secrets
- Remove outdated MAVEN_USERNAME and MAVEN_PASSWORD environment variables

