### PR TITLE
perf(core): add transient annotation for permission indexers

### DIFF
--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/permission/AppPermissionData.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/permission/AppPermissionData.kt
@@ -23,6 +23,7 @@ data class AppPermissionData(
     override val condition: ConditionMatcher = AllConditionMatcher.INSTANCE,
     override val groups: List<PermissionGroup> = listOf()
 ) : AppPermission {
+    @delegate:Transient
     override val permissionIndexer: Map<String, me.ahoo.cosec.api.permission.Permission> by lazy(this) {
         super.permissionIndexer
     }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/permission/AppRolePermissionData.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/permission/AppRolePermissionData.kt
@@ -22,6 +22,7 @@ data class AppRolePermissionData(
     override val appPermission: AppPermission,
     override val rolePermissions: List<RolePermission>
 ) : AppRolePermission {
+    @delegate:Transient
     override val rolePermissionIndexer: Map<String, List<Permission>> by lazy(this) {
         super.rolePermissionIndexer
     }


### PR DESCRIPTION
- Annotate permissionIndexer in AppPermissionData with @delegate:Transient
- Annotate rolePermissionIndexer in AppRolePermissionData with @delegate:Transient
- These changes may reduce memory footprint by not serializing these properties
