### PR TITLE
refactor(principal): replace fun isRoot() with val isRoot for CoSecPrincipal

### DIFF
--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/principal/CoSecPrincipal.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/principal/CoSecPrincipal.kt
@@ -53,8 +53,10 @@ interface CoSecPrincipal : Principal, PolicyCapable, RoleCapable {
          */
         const val ANONYMOUS_ID = CoSec.DEFAULT
 
-        fun CoSecPrincipal.isRoot(): Boolean {
-            return ROOT_ID == id
-        }
+        /**
+         * 是否是根账号
+         */
+        val CoSecPrincipal.isRoot: Boolean
+            get() = ROOT_ID == id
     }
 }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
@@ -150,7 +150,7 @@ class SimpleAuthorization(
     }
 
     private fun verifyRoot(context: SecurityContext): VerifyResult {
-        return if (context.principal.isRoot()) {
+        return if (context.principal.isRoot) {
             log.debug {
                 "Verify [$context] matched Root - [Allow]."
             }


### PR DESCRIPTION


- Change isRoot() method to isRoot property in CoSecPrincipal class
- Update usage of isRoot in SimpleAuthorization class
- Improve code readability and follow Kotlin conventions

