### PR TITLE
feat(policy): add support for composite action matcher in JSON

### DIFF
--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/CompositeActionMatcher.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/CompositeActionMatcher.kt
@@ -34,6 +34,7 @@ class CompositeActionMatcher(
 class CompositeActionMatcherFactory : ActionMatcherFactory {
     companion object {
         const val TYPE = "composite"
+        val INSTANCE = CompositeActionMatcherFactory()
     }
 
     override val type: String

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/serialization/JsonActionMatcherSerializer.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/serialization/JsonActionMatcherSerializer.kt
@@ -24,6 +24,7 @@ import me.ahoo.cosec.configuration.JsonConfiguration
 import me.ahoo.cosec.policy.action.ActionMatcherFactoryProvider
 import me.ahoo.cosec.policy.action.AllActionMatcher
 import me.ahoo.cosec.policy.action.AllActionMatcherFactory
+import me.ahoo.cosec.policy.action.CompositeActionMatcherFactory
 import me.ahoo.cosec.policy.action.PathActionMatcherFactory
 
 object JsonActionMatcherSerializer : StdSerializer<ActionMatcher>(ActionMatcher::class.java) {
@@ -44,12 +45,15 @@ object JsonActionMatcherDeserializer : StdDeserializer<ActionMatcher>(ActionMatc
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): ActionMatcher {
         val actionConfiguration = p.codec.readValue(p, JsonConfiguration::class.java)
 
-        if (actionConfiguration.isString && actionConfiguration.asString() == AllActionMatcherFactory.ALL) {
-            return AllActionMatcher.INSTANCE
+        if (actionConfiguration.isString) {
+            if (actionConfiguration.asString() == AllActionMatcherFactory.ALL) {
+                return AllActionMatcher.INSTANCE
+            }
+            return PathActionMatcherFactory.INSTANCE.create(actionConfiguration)
         }
 
-        if (actionConfiguration.isString || actionConfiguration.isArray) {
-            return PathActionMatcherFactory.INSTANCE.create(actionConfiguration)
+        if (actionConfiguration.isArray) {
+            return CompositeActionMatcherFactory.INSTANCE.create(actionConfiguration)
         }
 
         require(actionConfiguration.isObject)

--- a/cosec-core/src/test/resources/cosec-policy/test-policy.json
+++ b/cosec-core/src/test/resources/cosec-policy/test-policy.json
@@ -253,6 +253,39 @@
           "value": "#{principal.id}"
         }
       }
+    },
+    {
+      "name": "compositeAction",
+      "action": {
+        "composite": [
+          {
+            "path": {
+              "pattern": "/user/#{principal.id}/*"
+            }
+          },
+          {
+            "path": {
+              "pattern": "/user/#{principal.id}/order/*"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "arrayAction",
+      "action": [
+        "/user/#{principal.id}/*",
+        {
+          "path": {
+            "pattern": "/user/#{principal.id}/*"
+          }
+        },
+        {
+          "path": {
+            "pattern": "/user/#{principal.id}/order/*"
+          }
+        }
+      ]
     }
   ]
 }

--- a/schema/action.schema.json
+++ b/schema/action.schema.json
@@ -9,7 +9,10 @@
     {
       "type": "array",
       "items": {
-        "type": "string"
+        "anyOf": [
+          {"type": "string"},
+          {"$ref": "#"}
+        ]
       },
       "uniqueItems": true
     },


### PR DESCRIPTION
- Implement CompositeActionMatcherFactory with a constant INSTANCE
- Update JsonActionMatcherSerializer to handle composite action matcher:
  - Add support for parsing array-type action configurations
  - Use CompositeActionMatcherFactory for array-type configurations
  - Maintain existing behavior for string-type configurations


