### PR TITLE
feat(config): enable response compression and set server port

### DIFF
--- a/cosec-gateway-server/src/dist/config/application.yaml
+++ b/cosec-gateway-server/src/dist/config/application.yaml
@@ -1,7 +1,10 @@
 server:
+  port: 8080
   error:
     whitelabel:
       enabled: false
+  compression:
+    enabled: true
 cosec:
   authentication:
     enabled: false

--- a/cosec-gateway-server/src/main/resources/application.yaml
+++ b/cosec-gateway-server/src/main/resources/application.yaml
@@ -3,6 +3,8 @@ server:
   error:
     whitelabel:
       enabled: false
+  compression:
+    enabled: true
 spring:
   cloud:
     gateway:


### PR DESCRIPTION
- Enable response compression in both distribution and main application configurations
- Set server port to 8080 in the distribution configuration


