### PR TITLE
documentation(skills): publish CoSec skill metadata

### DIFF
--- a/skills/cosec-custom-matcher/SKILL.md
+++ b/skills/cosec-custom-matcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cosec-custom-matcher
-description: "Help developers create custom ActionMatcher and ConditionMatcher implementations for CoSec. Use this skill when users need to extend CoSec's policy matching with custom logic, implement a new condition type, create a custom action matcher, or register SPI extensions."
+description: "Use when extending CoSec policy matching with custom ActionMatcher or ConditionMatcher implementations, condition types, matcher factories, ServiceLoader SPI registration, or Spring bean matcher registration."
 ---
 
 # CoSec Custom Matcher Development

--- a/skills/cosec-custom-matcher/agents/openai.yaml
+++ b/skills/cosec-custom-matcher/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CoSec Custom Matchers"
+  short_description: "Build CoSec matcher extensions"
+  default_prompt: "Use $cosec-custom-matcher to implement a custom CoSec condition matcher and register it with SPI."

--- a/skills/cosec-integration/SKILL.md
+++ b/skills/cosec-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cosec-integration
-description: "Guide developers through integrating CoSec security framework into Spring Boot applications. Use this skill whenever the user asks about adding CoSec to a project, configuring CoSec properties, setting up JWT authentication, enabling authorization filters, adding Redis caching for policies, or integrating CoSec with WebFlux, WebMVC, or Spring Cloud Gateway."
+description: "Use when adding CoSec to a Spring Boot application, choosing WebFlux/WebMVC/Gateway modules, configuring JWT authentication, authorization filters, local policies, Redis policy caching, social login, IP enrichment, OpenAPI, or OpenTelemetry integration."
 ---
 
 # CoSec Integration Guide

--- a/skills/cosec-integration/agents/openai.yaml
+++ b/skills/cosec-integration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CoSec Integration"
+  short_description: "Integrate CoSec in Spring Boot"
+  default_prompt: "Use $cosec-integration to add CoSec to a Spring Boot service with JWT and authorization policies."

--- a/skills/cosec-policy-author/SKILL.md
+++ b/skills/cosec-policy-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cosec-policy-author
-description: "Author, validate, and explain CoSec security policy JSON files. Use this skill whenever the user mentions writing, creating, editing, or debugging CoSec policies, policy statements, action matchers, condition matchers, or authorization rules. Also use when users ask about policy JSON format, how to allow/deny specific endpoints, how to set up role-based access, or how to configure rate limiting in CoSec policies."
+description: "Use when writing, validating, explaining, or debugging CoSec policy JSON, policy statements, ALLOW/DENY rules, action matchers, condition matchers, role-based authorization, tenant scoping, or rate limiting policies."
 ---
 
 # CoSec Policy Authoring

--- a/skills/cosec-policy-author/agents/openai.yaml
+++ b/skills/cosec-policy-author/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CoSec Policy Authoring"
+  short_description: "Write CoSec authorization policies"
+  default_prompt: "Use $cosec-policy-author to draft and validate CoSec policy JSON for my endpoints."

--- a/skills/cosec-troubleshoot/SKILL.md
+++ b/skills/cosec-troubleshoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cosec-troubleshoot
-description: "Debug and troubleshoot CoSec authorization issues. Use this skill when users report unexpected 403/401 errors, requests being denied when they should be allowed, policies not taking effect, JWT token issues, or need to understand why a specific request was authorized or denied."
+description: "Use when diagnosing CoSec authentication or authorization failures such as unexpected 401/403 responses, denied requests that should be allowed, policies not loading, JWT token rejection, matcher mismatches, or unclear access decisions."
 ---
 
 # CoSec Troubleshooting Guide

--- a/skills/cosec-troubleshoot/agents/openai.yaml
+++ b/skills/cosec-troubleshoot/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CoSec Troubleshooting"
+  short_description: "Debug CoSec access decisions"
+  default_prompt: "Use $cosec-troubleshoot to diagnose why a CoSec request is denied or a JWT is rejected."

--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "plugins": [
+    {
+      "name": "ahoo-cosec-skills",
+      "description": "CoSec skills for integrating a reactive multi-tenant RBAC and policy-based security framework, authoring authorization policies, extending matchers, and troubleshooting access decisions.",
+      "skills": {
+        "include": [
+          "cosec-custom-matcher",
+          "cosec-integration",
+          "cosec-policy-author",
+          "cosec-troubleshoot"
+        ],
+        "exclude": [
+          "*-workspace"
+        ]
+      },
+      "keywords": [
+        "cosec",
+        "security",
+        "authorization",
+        "authentication",
+        "rbac",
+        "policy",
+        "multi-tenant",
+        "spring-boot",
+        "reactive",
+        "jwt"
+      ],
+      "category": "development",
+      "interface": {
+        "displayName": "Ahoo CoSec Skills",
+        "capabilities": [
+          "Skills"
+        ],
+        "defaultPrompt": "Help me integrate CoSec, author authorization policies, implement custom matchers, and troubleshoot authentication or authorization issues."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `skills/plugins.json` as platform-neutral source metadata for publishing CoSec skills through the Ahoo skills marketplace.
- Add `agents/openai.yaml` UI metadata for each existing CoSec skill.
- Refine skill frontmatter descriptions so discovery is trigger-focused and domain-specific.

## Validation

- `uv run --with pyyaml python /Users/ahoo/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>` for all four skills
- Validated each `agents/openai.yaml` default prompt and short description constraints
- `jq empty skills/plugins.json`
- Verified `plugins.json` include list matches current non-`*-workspace` skill directories
- `git diff --check -- skills`
- `./gradlew detekt`
