### PR TITLE
fix(webmvc): clear SecurityContext thread-local after request to prevent cross-request bleed

### DIFF
--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AuthorizationFilter.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AuthorizationFilter.kt
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.context.SecurityContextHolder
 import me.ahoo.cosec.context.SecurityContextParser
 import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
@@ -57,22 +58,29 @@ class AuthorizationFilter(
     ) {
         val httpServletRequest = request as HttpServletRequest
         val httpServletResponse = response as HttpServletResponse
+        // authorize() binds the SecurityContext to the current (pooled) thread via SecurityContextHolder.
+        // It must be removed once the request completes, otherwise it bleeds into the next request served
+        // by the same worker thread. Cleanup runs on every exit path, including early returns and errors.
         try {
-            if (!authorize(httpServletRequest, httpServletResponse)) {
+            try {
+                if (!authorize(httpServletRequest, httpServletResponse)) {
+                    return
+                }
+            } catch (tooManyRequestsException: TooManyRequestsException) {
+                response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+                httpServletResponse.writeWithAuthorizeResult(AuthorizeResult.TOO_MANY_REQUESTS)
+            } catch (cause: Exception) {
+                log.error(cause) {
+                    "Unexpected error during authorization of request [${httpServletRequest.servletPath}] [${httpServletRequest.method}]."
+                }
+                httpServletResponse.status = HttpStatus.INTERNAL_SERVER_ERROR.value()
+                httpServletResponse.writeWithAuthorizeResult(AuthorizeResult.IMPLICIT_DENY)
                 return
             }
-        } catch (tooManyRequestsException: TooManyRequestsException) {
-            response.status = HttpStatus.TOO_MANY_REQUESTS.value()
-            httpServletResponse.writeWithAuthorizeResult(AuthorizeResult.TOO_MANY_REQUESTS)
-        } catch (cause: Exception) {
-            log.error(cause) {
-                "Unexpected error during authorization of request [${httpServletRequest.servletPath}] [${httpServletRequest.method}]."
-            }
-            httpServletResponse.status = HttpStatus.INTERNAL_SERVER_ERROR.value()
-            httpServletResponse.writeWithAuthorizeResult(AuthorizeResult.IMPLICIT_DENY)
-            return
-        }
 
-        chain.doFilter(request, response)
+            chain.doFilter(request, response)
+        } finally {
+            SecurityContextHolder.remove()
+        }
     }
 }

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilter.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilter.kt
@@ -45,8 +45,14 @@ class InjectSecurityContextFilter(
 
     @Throws(IOException::class, ServletException::class)
     override fun doFilter(servletRequest: ServletRequest, servletResponse: ServletResponse, filterChain: FilterChain) {
-        tryInjectSecurityContext(servletRequest)
-        filterChain.doFilter(servletRequest, servletResponse)
+        // The injected SecurityContext is bound to the current (pooled) thread; remove it once the request
+        // completes so it cannot bleed into the next request served by the same worker thread.
+        try {
+            tryInjectSecurityContext(servletRequest)
+            filterChain.doFilter(servletRequest, servletResponse)
+        } finally {
+            SecurityContextHolder.remove()
+        }
     }
 
     private fun tryInjectSecurityContext(servletRequest: ServletRequest) {

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
@@ -24,6 +24,7 @@ import jakarta.servlet.http.HttpServletResponse
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.api.context.request.RequestIdCapable
+import me.ahoo.cosec.api.principal.CoSecPrincipal
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.context.SecurityContextHolder
 import me.ahoo.cosec.context.SecurityContextParser
@@ -34,6 +35,7 @@ import me.ahoo.cosec.servlet.ServletRequests.setSecurityContext
 import me.ahoo.cosec.token.TokenVerificationException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -68,11 +70,17 @@ internal class AuthorizationFilterTest {
         val servletResponse = mockk<HttpServletResponse> {
             every { setHeader(RequestIdCapable.REQUEST_ID_KEY, any()) } just runs
         }
+        var principalDuringChain: CoSecPrincipal? = null
         val filterChain = mockk<FilterChain> {
-            every { doFilter(servletRequest, any()) } returns Unit
+            every { doFilter(servletRequest, any()) } answers {
+                principalDuringChain = SecurityContextHolder.context?.principal
+            }
         }
         filter.doFilter(servletRequest, servletResponse, filterChain)
-        assertThat(SecurityContextHolder.requiredContext.principal, equalTo(SimpleTenantPrincipal.ANONYMOUS))
+        // The security context is available to the downstream chain ...
+        assertThat(principalDuringChain, equalTo(SimpleTenantPrincipal.ANONYMOUS))
+        // ... but is removed afterwards so it cannot bleed into the next request on a pooled thread.
+        assertThat(SecurityContextHolder.context, nullValue())
     }
 
     @Test
@@ -108,7 +116,8 @@ internal class AuthorizationFilterTest {
             every { doFilter(servletRequest, any()) } returns Unit
         }
         filter.doFilter(servletRequest, servletResponse, filterChain)
-        assertThat(SecurityContextHolder.requiredContext.principal, equalTo(SimpleTenantPrincipal.ANONYMOUS))
+        // A denied request must not leave its security context bound to the (pooled) request thread.
+        assertThat(SecurityContextHolder.context, nullValue())
     }
 
     @Test

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilterTest.kt
@@ -18,6 +18,7 @@ import io.mockk.mockk
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import me.ahoo.cosec.api.context.request.RequestIdCapable
+import me.ahoo.cosec.api.principal.CoSecPrincipal
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.context.SecurityContextHolder
 import me.ahoo.cosec.jwt.InjectSecurityContextParser
@@ -44,11 +45,17 @@ internal class InjectSecurityContextFilterTest {
             every { getHeader(HttpHeaders.REFERER) } returns null
             every { setSecurityContext(any()) } returns Unit
         }
+        var principalDuringChain: CoSecPrincipal? = null
         val filterChain = mockk<FilterChain> {
-            every { doFilter(request, any()) } returns Unit
+            every { doFilter(request, any()) } answers {
+                principalDuringChain = SecurityContextHolder.context?.principal
+            }
         }
         filter.doFilter(request, mockk(), filterChain)
-        assertThat(SecurityContextHolder.requiredContext.principal, equalTo(SimpleTenantPrincipal.ANONYMOUS))
+        // The security context is available to the downstream chain ...
+        assertThat(principalDuringChain, equalTo(SimpleTenantPrincipal.ANONYMOUS))
+        // ... but is removed afterwards so it cannot bleed into the next request on a pooled thread.
+        assertThat(SecurityContextHolder.context, nullValue())
     }
 
     @Test


### PR DESCRIPTION
## What & why

In the servlet integration, both filters bind the `SecurityContext` to the current thread via `SecurityContextHolder` (backed by an `InheritableThreadLocal`) but **never call `SecurityContextHolder.remove()`**:

- `AuthorizationFilter` → `AbstractAuthorizationInterceptor.authorize()` calls `SecurityContextHolder.setContext(...)` ([AbstractAuthorizationInterceptor.kt](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt))
- `InjectSecurityContextFilter` → `tryInjectSecurityContext()` calls `SecurityContextHolder.setContext(...)`

Servlet containers reuse worker threads from a pool, so a stale principal stays bound to the thread after the request completes. A later request served by the same thread on a path that reads `SecurityContextHolder` **before** its own filter overwrites it (a permitted/static path, or an async dispatch) can observe the **previous request's principal** — a cross-request identity / authorization-confusion risk.

## Fix

Wrap each filter's `doFilter` body in `try { ... } finally { SecurityContextHolder.remove() }`, so cleanup runs on **every** exit path — allow, deny, token-invalid, rate-limited, and unexpected-error early returns. The context remains available to the downstream chain during the request and is removed once it unwinds.

The change is behavior-preserving otherwise; existing control flow (status codes, error handling) is untouched.

## Tests

The existing filter tests asserted the context was still present **after** `doFilter` returned — i.e. they encoded the leak. They now assert the correct contract:
- the principal is available to the chain **during** `doFilter`, and
- `SecurityContextHolder.context` is **null after** `doFilter` (allow and deny paths).

Verified RED first (3 tests failed `Expected: null`), then GREEN. Full `:cosec-webmvc:test` + `:cosec-webmvc:detekt` pass.

## Reviewer notes

- `SecurityContextHolder` is left as an `InheritableThreadLocal`. Switching it to a plain `ThreadLocal` would additionally harden against stale context captured by threads *spawned mid-request*, but that is a behavioral change (child threads would no longer inherit the principal), so it's left as a separate decision rather than bundled here.
- Out of scope, flagged separately: in `AuthorizationFilter.doFilter` the `TooManyRequestsException` branch writes a 429 but does not `return`, so it currently falls through to `chain.doFilter`. This PR preserves that existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)