### PR TITLE
chore(deps): upgrade cosid to 3.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # libraries
 spring-boot = "4.1.0"
 spring-cloud = "2025.1.2"
-cosid = "3.0.5"
+cosid = "3.2.0"
 cocache = "4.0.2"
 opentelemetry = "2.26.1"
 testcontainers = "2.0.5"


### PR DESCRIPTION
## 变更内容

升级 `cosid` 版本 `3.0.5` → `3.2.0`。

`gradle/libs.versions.toml`:
```diff
- cosid = "3.0.5"
+ cosid = "3.2.0"
```

`cosid-bom` 被以下模块引用:
- cosec-jwt(`cosid-core` api)
- cosec-social(`cosid-core` api)
- cosec-cocache / cosec-webflux / cosec-webmvc / cosec-spring-boot-starter(`cosid-test`)

## 验证

- [x] 依赖解析通过(cosid-core / cosid-bom 3.2.0 成功下载)
- [x] `./gradlew detekt build -x test` → BUILD SUCCESSFUL