### PR TITLE
chore(deps): upgrade cocache to 4.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 spring-boot = "4.1.0"
 spring-cloud = "2025.1.2"
 cosid = "3.2.0"
-cocache = "4.0.2"
+cocache = "4.2.0"
 opentelemetry = "2.26.1"
 testcontainers = "2.0.5"
 guava = "33.5.0-jre"


### PR DESCRIPTION
## 变更内容

升级 `cocache` 版本 `4.0.2` → `4.2.0`。

`gradle/libs.versions.toml`:
```diff
- cocache = "4.0.2"
+ cocache = "4.2.0"
```

`cocache-bom` 主要被 `cosec-cocache` 模块(Redis 策略/权限缓存)引用。

## 验证

- [x] 依赖解析通过(cocache-core / cocache-bom 4.2.0 成功下载)
- [x] `./gradlew detekt build -x test` → BUILD SUCCESSFUL