### PR TITLE
chore(release): bump version to 4.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosec
-version=4.3.6
+version=4.5.0
 description=RBAC-based And Policy-based Multi-Tenant Reactive Security Framework.
 website=https://github.com/Ahoo-Wang/CoSec
 issues=https://github.com/Ahoo-Wang/CoSec/issues


### PR DESCRIPTION
## 变更内容

发布版本 `v4.5.0`,更新 `gradle.properties`:
```diff
- version=4.3.6
+ version=4.5.0
```

## 自 v4.3.5 以来的主要变更

### 🛡️ 安全修复
- **fix(core): sandbox OGNL condition matcher against expression injection (#778)**
- **fix(core): bound RegularConditionMatcher regex matching against ReDoS (#780)**
- fix(webmvc): clear SecurityContext thread-local after request to prevent cross-request bleed (#779)

### 🎉 新特性
- feat(rograph): add service edge adapter

### 🤖 依赖升级
- Spring Boot 4.0.5 → 4.1.0 / Spring Cloud 2025.1.1 → 2025.1.2
- cosid 3.0.5 → 3.2.0
- cocache 4.0.2 → 4.2.0
- guava 33.5.0-jre → 33.6.0-jre
- java-jwt、swagger、testcontainers、kotlin.logging 等多项升级

合并后将在 bump commit 上打 tag `v4.5.0` 并创建 GitHub Release(自动触发制品发布到 Maven Central)。