### PR TITLE
fix(wiki): approve esbuild build scripts for pnpm v11

### DIFF
--- a/wiki/pnpm-workspace.yaml
+++ b/wiki/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Problem

The `Deploy Wiki to GitHub Pages` workflow has been failing since pnpm was upgraded to v11 (2026-07-22, runs #806/#808/#809):

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.21.5
```

## Root cause

`esbuild` (a transitive dependency of `vitepress`) runs a `postinstall` to fetch its native binary. pnpm v10+ blocks dependency build scripts by default for supply-chain safety, and exits non-zero in CI when scripts are ignored.

`pnpm v11` no longer reads the `pnpm` field in `package.json`; build-script approvals now live in `pnpm-workspace.yaml`.

## Fix

Add `wiki/pnpm-workspace.yaml`:

```yaml
allowBuilds:
  esbuild: true
```

Same fix already applied to GodeX (#201) and already present in CoApi/Simba/CoCache wikis.

## Verification

Locally reproduced the failure on `main`, then confirmed the fix:

```
$ pnpm install --frozen-lockfile   # Done in 1.1s, no ignored-builds warning
$ pnpm build                       # build complete in 6.17s
```