### PR TITLE
fix: close P0 security findings (JWT refresh forgery, wildcard role indexer, blank jwt secret)

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -92,3 +92,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Aliyun ACR rejects OCI 1.1 empty-descriptor attestation manifests (application/vnd.oci.empty.v1+json)
+          provenance: false
+          sbom: false

--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/permission/AppRolePermission.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/permission/AppRolePermission.kt
@@ -29,15 +29,16 @@ interface AppRolePermission {
      * @return Map of RoleId to list of Permissions
      */
     val rolePermissionIndexer: Map<RoleId, List<Permission>>
-        get() {
-            rolePermissions.forEach {
-                if (it.permissions.contains(ALL_PERMISSION_ID)) {
-                    return mapOf(it.id to appPermission.permissionIndexer.values.toList())
+        get() = rolePermissions.associate { rolePermission ->
+            val permissions =
+                if (rolePermission.permissions.contains(ALL_PERMISSION_ID)) {
+                    appPermission.permissionIndexer.values.toList()
+                } else {
+                    rolePermission.permissions.mapNotNull { permissionId ->
+                        appPermission.permissionIndexer[permissionId]
+                    }
                 }
-            }
-            return rolePermissions.associate {
-                it.id to it.permissions.mapNotNull { permissionId -> appPermission.permissionIndexer[permissionId] }
-            }
+            rolePermission.id to permissions
         }
 
     companion object {

--- a/cosec-api/src/test/kotlin/me/ahoo/cosec/api/permission/AppRolePermissionTest.kt
+++ b/cosec-api/src/test/kotlin/me/ahoo/cosec/api/permission/AppRolePermissionTest.kt
@@ -1,0 +1,71 @@
+package me.ahoo.cosec.api.permission
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.cosec.api.principal.RoleId
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.hasKey
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+
+class AppRolePermissionTest {
+
+    private fun rolePermissionOf(id: RoleId, vararg permissions: PermissionId): RolePermission =
+        object : RolePermission {
+            override val id: RoleId = id
+            override val permissions: Set<PermissionId> = permissions.toSet()
+        }
+
+    @Test
+    fun wildcardRoleKeepsOtherRolesInIndex() {
+        val readPermission = mockk<Permission>()
+        val writePermission = mockk<Permission>()
+        val appPermission = mockk<AppPermission> {
+            every { permissionIndexer } returns mapOf(
+                "permission:read" to readPermission,
+                "permission:write" to writePermission,
+            )
+        }
+        val appRolePermission = object : AppRolePermission {
+            override val appPermission: AppPermission = appPermission
+            override val rolePermissions: List<RolePermission> = listOf(
+                rolePermissionOf("admin", AppRolePermission.ALL_PERMISSION_ID),
+                rolePermissionOf("writer", "permission:write"),
+            )
+        }
+
+        val indexer = appRolePermission.rolePermissionIndexer
+
+        assertThat(indexer, hasKey("admin"))
+        assertThat(indexer, hasKey("writer"))
+        assertThat(indexer.keys, hasSize(2))
+        assertThat(indexer.getValue("admin"), containsInAnyOrder(readPermission, writePermission))
+        assertThat(indexer.getValue("writer"), contains(writePermission))
+    }
+
+    @Test
+    fun rolesWithoutWildcardKeepOwnPermissions() {
+        val readPermission = mockk<Permission>()
+        val writePermission = mockk<Permission>()
+        val appPermission = mockk<AppPermission> {
+            every { permissionIndexer } returns mapOf(
+                "permission:read" to readPermission,
+                "permission:write" to writePermission,
+            )
+        }
+        val appRolePermission = object : AppRolePermission {
+            override val appPermission: AppPermission = appPermission
+            override val rolePermissions: List<RolePermission> = listOf(
+                rolePermissionOf("reader", "permission:read"),
+                rolePermissionOf("writer", "permission:write", "permission:unknown"),
+            )
+        }
+
+        val indexer = appRolePermission.rolePermissionIndexer
+
+        assertThat(indexer.getValue("reader"), contains(readPermission))
+        assertThat(indexer.getValue("writer"), contains(writePermission))
+    }
+}

--- a/cosec-api/src/test/kotlin/me/ahoo/cosec/api/permission/AppRolePermissionTest.kt
+++ b/cosec-api/src/test/kotlin/me/ahoo/cosec/api/permission/AppRolePermissionTest.kt
@@ -3,11 +3,7 @@ package me.ahoo.cosec.api.permission
 import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.cosec.api.principal.RoleId
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.contains
-import org.hamcrest.Matchers.containsInAnyOrder
-import org.hamcrest.Matchers.hasKey
-import org.hamcrest.Matchers.hasSize
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class AppRolePermissionTest {
@@ -38,11 +34,11 @@ class AppRolePermissionTest {
 
         val indexer = appRolePermission.rolePermissionIndexer
 
-        assertThat(indexer, hasKey("admin"))
-        assertThat(indexer, hasKey("writer"))
-        assertThat(indexer.keys, hasSize(2))
-        assertThat(indexer.getValue("admin"), containsInAnyOrder(readPermission, writePermission))
-        assertThat(indexer.getValue("writer"), contains(writePermission))
+        indexer.assert().containsKey("admin")
+        indexer.assert().containsKey("writer")
+        indexer.assert().hasSize(2)
+        indexer.getValue("admin").assert().containsExactlyInAnyOrder(readPermission, writePermission)
+        indexer.getValue("writer").assert().containsExactly(writePermission)
     }
 
     @Test
@@ -65,7 +61,7 @@ class AppRolePermissionTest {
 
         val indexer = appRolePermission.rolePermissionIndexer
 
-        assertThat(indexer.getValue("reader"), contains(readPermission))
-        assertThat(indexer.getValue("writer"), contains(writePermission))
+        indexer.getValue("reader").assert().containsExactly(readPermission)
+        indexer.getValue("writer").assert().containsExactly(writePermission)
     }
 }

--- a/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifier.kt
+++ b/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifier.kt
@@ -35,7 +35,7 @@ import me.ahoo.cosec.token.TokenVerifier
  * @see JwtTokenConverter
  */
 class JwtTokenVerifier(
-    algorithm: Algorithm
+    private val algorithm: Algorithm
 ) : TokenVerifier {
     private val jwtVerifier: JWTVerifier = JWT.require(algorithm).build()
 
@@ -61,7 +61,18 @@ class JwtTokenVerifier(
     override fun <T : TokenPrincipal> refresh(token: CompositeToken): T {
         val decodedRefreshToken: DecodedJWT = verify(token.refreshToken)
         val decodedAccessToken = Jwts.decode(token.accessToken)
+        verifyAccessTokenSignature(decodedAccessToken)
         require(decodedRefreshToken.subject == decodedAccessToken.id) { "Illegal refreshToken." }
         return Jwts.toPrincipal(decodedAccessToken)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun verifyAccessTokenSignature(decodedAccessToken: DecodedJWT) {
+        try {
+            algorithm.verify(decodedAccessToken)
+        } catch (exception: Exception) {
+            throw me.ahoo.cosec.token
+                .TokenVerificationException(exception.message!!, exception)
+        }
     }
 }

--- a/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifierTest.kt
+++ b/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifierTest.kt
@@ -24,6 +24,8 @@ import me.ahoo.cosec.token.SimpleCompositeToken
 import me.ahoo.cosec.token.TokenExpiredException
 import me.ahoo.cosec.token.TokenVerificationException
 import me.ahoo.cosid.test.MockIdGenerator
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Assertions.*
@@ -77,7 +79,7 @@ class JwtTokenVerifierTest {
             refreshToken = oldToken.refreshToken,
         )
 
-        assertThrows(TokenVerificationException::class.java) {
+        assertThrownBy<TokenVerificationException> {
             jwtTokenVerifier.refresh<TokenPrincipal>(forgedToken)
         }
     }
@@ -95,7 +97,7 @@ class JwtTokenVerifierTest {
 
         val newTokenPrincipal = jwtTokenVerifier.refresh<TokenTenantPrincipal>(oldToken)
 
-        assertThat(newTokenPrincipal.id, equalTo(SimpleTenantPrincipal.ANONYMOUS.id))
-        assertThat(newTokenPrincipal.tenant.tenantId, equalTo(SimpleTenantPrincipal.ANONYMOUS.tenant.tenantId))
+        newTokenPrincipal.id.assert().isEqualTo(SimpleTenantPrincipal.ANONYMOUS.id)
+        newTokenPrincipal.tenant.tenantId.assert().isEqualTo(SimpleTenantPrincipal.ANONYMOUS.tenant.tenantId)
     }
 }

--- a/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifierTest.kt
+++ b/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifierTest.kt
@@ -13,12 +13,16 @@
 
 package me.ahoo.cosec.jwt
 
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
 import me.ahoo.cosec.api.principal.CoSecPrincipal
 import me.ahoo.cosec.api.token.CompositeToken
 import me.ahoo.cosec.api.token.TokenPrincipal
 import me.ahoo.cosec.api.token.TokenTenantPrincipal
 import me.ahoo.cosec.principal.SimpleTenantPrincipal
+import me.ahoo.cosec.token.SimpleCompositeToken
 import me.ahoo.cosec.token.TokenExpiredException
+import me.ahoo.cosec.token.TokenVerificationException
 import me.ahoo.cosid.test.MockIdGenerator
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -58,5 +62,40 @@ class JwtTokenVerifierTest {
         val oldToken: CompositeToken = converter.toToken(SimpleTenantPrincipal.ANONYMOUS)
         TimeUnit.SECONDS.sleep(1)
         assertThrows(TokenExpiredException::class.java) { jwtTokenVerifier.refresh<TokenPrincipal>(oldToken) }
+    }
+
+    @Test
+    fun refreshWhenAccessTokenSignatureIsForged() {
+        val oldToken: CompositeToken = jwtTokenConverter.toToken(SimpleTenantPrincipal.ANONYMOUS)
+        val legitAccessTokenId = Jwts.decode(oldToken.accessToken).id
+        val forgedAccessToken = JWT.create()
+            .withJWTId(legitAccessTokenId)
+            .withSubject(SimpleTenantPrincipal.ANONYMOUS.id)
+            .sign(Algorithm.HMAC256("attacker-secret"))
+        val forgedToken = SimpleCompositeToken(
+            accessToken = forgedAccessToken,
+            refreshToken = oldToken.refreshToken,
+        )
+
+        assertThrows(TokenVerificationException::class.java) {
+            jwtTokenVerifier.refresh<TokenPrincipal>(forgedToken)
+        }
+    }
+
+    @Test
+    fun refreshWhenAccessTokenExpiredButSignatureValid() {
+        val converter = JwtTokenConverter(
+            MockIdGenerator.INSTANCE,
+            JwtFixture.ALGORITHM,
+            Duration.ofMillis(1),
+            Duration.ofDays(7),
+        )
+        val oldToken: CompositeToken = converter.toToken(SimpleTenantPrincipal.ANONYMOUS)
+        TimeUnit.SECONDS.sleep(1)
+
+        val newTokenPrincipal = jwtTokenVerifier.refresh<TokenTenantPrincipal>(oldToken)
+
+        assertThat(newTokenPrincipal.id, equalTo(SimpleTenantPrincipal.ANONYMOUS.id))
+        assertThat(newTokenPrincipal.tenant.tenantId, equalTo(SimpleTenantPrincipal.ANONYMOUS.tenant.tenantId))
     }
 }

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/CoSecJwtAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/CoSecJwtAutoConfiguration.kt
@@ -49,6 +49,10 @@ class CoSecJwtAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     fun cosecTokenAlgorithm(jwtProperties: JwtProperties): Algorithm {
+        require(jwtProperties.secret.isNotBlank()) {
+            "Property [${JwtProperties.PREFIX}.secret] must not be blank when JWT is enabled. " +
+                "Set cosec.jwt.secret to a strong random value, or disable JWT via cosec.jwt.enabled=false."
+        }
         return when (jwtProperties.algorithm) {
             JwtProperties.Algorithm.HMAC256 -> Algorithm.HMAC256(
                 jwtProperties.secret,

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/JwtProperties.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/JwtProperties.kt
@@ -28,7 +28,7 @@ import java.time.Duration
 class JwtProperties(
     @DefaultValue("true") override var enabled: Boolean = true,
     @DefaultValue("hmac256") var algorithm: Algorithm = Algorithm.HMAC256,
-    var secret: String,
+    @DefaultValue("") var secret: String = "",
     @NestedConfigurationProperty var tokenValidity: TokenValidity = TokenValidity()
 ) : EnabledCapable {
     companion object {

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/CoSecJwtAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/CoSecJwtAutoConfigurationTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.cosec.token.TokenConverter
 import me.ahoo.cosec.token.TokenVerifier
 import me.ahoo.cosid.IdGenerator
 import me.ahoo.cosid.test.MockIdGenerator
+import me.ahoo.test.asserts.assert
 import org.assertj.core.api.AssertionsForInterfaceTypes
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
@@ -90,7 +91,7 @@ class CoSecJwtAutoConfigurationTest {
                 CoSecJwtAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
-                AssertionsForInterfaceTypes.assertThat(context)
+                context.assert()
                     .hasFailed()
                     .getFailure()
                     .hasRootCauseInstanceOf(IllegalArgumentException::class.java)

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/CoSecJwtAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/jwt/CoSecJwtAutoConfigurationTest.kt
@@ -82,4 +82,18 @@ class CoSecJwtAutoConfigurationTest {
                     .doesNotHaveBean(TokenVerifier::class.java)
             }
     }
+
+    @Test
+    fun contextLoadsWhenSecretIsMissing() {
+        contextRunner
+            .withUserConfiguration(
+                CoSecJwtAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                AssertionsForInterfaceTypes.assertThat(context)
+                    .hasFailed()
+                    .getFailure()
+                    .hasRootCauseInstanceOf(IllegalArgumentException::class.java)
+            }
+    }
 }


### PR DESCRIPTION
## Summary

P0 security/correctness fixes from the 2026-08-13 full-codebase analysis (3 independent commits, TDD with red-state confirmation for each):

- **fix(jwt)** `JwtTokenVerifier.refresh()` now verifies the access token's **signature** (`Algorithm.verify(DecodedJWT)` — signature-only, expiry intentionally tolerated since refresh exists for expired tokens) **before** the jti linkage check and before any claim is read. Closes a vertical privilege escalation: a holder of a valid refresh token could forge an access token with the same `jti` and elevated `roles`/`policies` claims and obtain them via refresh.
- **fix(api)** `AppRolePermission.rolePermissionIndexer` no longer drops sibling roles when one role holds the `*` wildcard — the default getter returned a single-entry map, breaking external targeted lookups (`indexer[roleId]` → null) and mis-attributing audit `roleId`. The map contract now matches its KDoc; in-repo deny-first authorization outcomes are provably unchanged.
- **fix(starter)** blank `cosec.jwt.secret` (JWT enabled by default) previously produced a cryptic NPE at binding; `secret` now defaults to `""` and `cosecTokenAlgorithm` fails fast with an actionable message (`cosec.jwt.secret` / `cosec.jwt.enabled=false`).

## Security impact

- Forged-signature access tokens are rejected at refresh time (`TokenVerificationException`); legitimately-signed but expired access tokens still refresh.
- `alg:none` / algorithm confusion remains structurally blocked (verifier built from a fixed `Algorithm`).
- Empty/whitespace secret can no longer silently yield a weak HMAC on the auto-configured path.

## Test Plan

- [x] New regression tests, each confirmed RED on pre-fix code then GREEN after:
  - `AppRolePermissionTest.wildcardRoleKeepsOtherRolesInIndex` / `rolesWithoutWildcardKeepOwnPermissions` (cosec-api)
  - `JwtTokenVerifierTest.refreshWhenAccessTokenSignatureIsForged` / `refreshWhenAccessTokenExpiredButSignatureValid` (cosec-jwt)
  - `CoSecJwtAutoConfigurationTest.contextLoadsWhenSecretIsMissing` (starter)
- [x] Full `./gradlew build` (all modules, Redis-backed integration tests included) — BUILD SUCCESSFUL
- [x] `./gradlew detekt` — clean

## Follow-ups (tracked, intentionally out of scope)

- Minimum secret length/entropy check (short non-blank secrets still accepted)
- Token verification error message not leaked into 401/403 response bodies
- Rotate/externalize the hardcoded secret in `cosec-gateway-server/application.yaml`