### PR TITLE
fix: close P1 findings (token reason leak, double condition evaluation, global index demotion, ip2region JAR loading, demo secret)

### DIFF
--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/RedisPolicyRepository.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/RedisPolicyRepository.kt
@@ -52,11 +52,13 @@ class RedisPolicyRepository(
             }
             DefaultPolicyEvaluator.evaluate(policy)
             policyCache[policy.id] = policy
+            val globalPolicies = globalPolicyIndexCache[CACHE_KEY]
             if (policy.type == PolicyType.GLOBAL) {
-                val globalPolicies = globalPolicyIndexCache[CACHE_KEY] ?: emptySet()
-                if (globalPolicies.contains(policy.id).not()) {
-                    globalPolicyIndexCache[CACHE_KEY] = globalPolicies + policy.id
+                if (globalPolicies == null || globalPolicies.contains(policy.id).not()) {
+                    globalPolicyIndexCache[CACHE_KEY] = (globalPolicies ?: emptySet()) + policy.id
                 }
+            } else if (globalPolicies != null && globalPolicies.contains(policy.id)) {
+                globalPolicyIndexCache[CACHE_KEY] = globalPolicies - policy.id
             }
         }
     }

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/RedisPolicyRepositoryTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/RedisPolicyRepositoryTest.kt
@@ -112,6 +112,7 @@ internal class RedisPolicyRepositoryTest {
     @Test
     fun setPolicyIfSystem() {
         val globalPolicyIndexCache = mockk<GlobalPolicyIndexCache>()
+        every { globalPolicyIndexCache.get(CACHE_KEY) } returns null
         val policyCache = mockPolicyCache()
         val policyRepository = RedisPolicyRepository(globalPolicyIndexCache, policyCache)
         val systemPolicy = PolicyData(
@@ -129,6 +130,59 @@ internal class RedisPolicyRepositoryTest {
 
         verify {
             policyCache.set(any(), any())
+        }
+    }
+
+    @Test
+    fun setPolicyWhenDemotedFromGlobal() {
+        val globalPolicyIndexCache = mockk<GlobalPolicyIndexCache>()
+        every { globalPolicyIndexCache.get(CACHE_KEY) } returns setOf(policyData.id)
+        every { globalPolicyIndexCache.set(CACHE_KEY, any()) } returns Unit
+        val policyCache = mockPolicyCache()
+        val policyRepository = RedisPolicyRepository(globalPolicyIndexCache, policyCache)
+        val systemPolicy = PolicyData(
+            id = "policyId",
+            category = "policyName",
+            name = "policyDesc",
+            description = "policyType",
+            type = PolicyType.SYSTEM,
+            tenantId = "tenantId",
+            statements = listOf(),
+        )
+        policyRepository.setPolicy(systemPolicy)
+            .test()
+            .verifyComplete()
+
+        verify {
+            policyCache.set(any(), any())
+            globalPolicyIndexCache.set(CACHE_KEY, emptySet())
+        }
+    }
+
+    @Test
+    fun setPolicyIfSystemWhenNotInGlobalIndex() {
+        val globalPolicyIndexCache = mockk<GlobalPolicyIndexCache>()
+        every { globalPolicyIndexCache.get(CACHE_KEY) } returns null
+        val policyCache = mockPolicyCache()
+        val policyRepository = RedisPolicyRepository(globalPolicyIndexCache, policyCache)
+        val systemPolicy = PolicyData(
+            id = "policyId",
+            category = "policyName",
+            name = "policyDesc",
+            description = "policyType",
+            type = PolicyType.SYSTEM,
+            tenantId = "tenantId",
+            statements = listOf(),
+        )
+        policyRepository.setPolicy(systemPolicy)
+            .test()
+            .verifyComplete()
+
+        verify {
+            policyCache.set(any(), any())
+        }
+        verify(exactly = 0) {
+            globalPolicyIndexCache.set(any(), any())
         }
     }
 

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
@@ -64,13 +64,14 @@ class SimpleAuthorization(
         crossinline verifyItem: (T) -> VerifyResult,
         crossinline onMatch: (T, VerifyResult) -> VerifyContext
     ): VerifyContext? {
-        items.filter { effectExtractor(it) == Effect.DENY }.forEach { item ->
+        val materializedItems = items.toList()
+        materializedItems.filter { effectExtractor(it) == Effect.DENY }.forEach { item ->
             val result = verifyItem(item)
             if (result == VerifyResult.EXPLICIT_DENY) {
                 return onMatch(item, result)
             }
         }
-        items.filter { effectExtractor(it) == Effect.ALLOW }.forEach { item ->
+        materializedItems.filter { effectExtractor(it) == Effect.ALLOW }.forEach { item ->
             val result = verifyItem(item)
             if (result == VerifyResult.ALLOW) {
                 return onMatch(item, result)

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
@@ -58,20 +58,27 @@ class SimpleAuthorization(
 
     private data class RolePermissionEntry(val roleId: RoleId, val permission: Permission)
 
+    /**
+     * Deny-first evaluation: all DENY items are verified before any ALLOW item, first match wins.
+     *
+     * The incoming sequence is materialized once so every upstream condition (e.g. a policy-level
+     * rate limiter) is evaluated exactly once per authorization — including conditions positioned
+     * after a matching early DENY — meaning denied requests uniformly consume rate-limiter permits.
+     */
     private inline fun <T> evaluateDenyFirst(
         items: Sequence<T>,
         crossinline effectExtractor: (T) -> Effect,
         crossinline verifyItem: (T) -> VerifyResult,
         crossinline onMatch: (T, VerifyResult) -> VerifyContext
     ): VerifyContext? {
-        val materializedItems = items.toList()
-        materializedItems.filter { effectExtractor(it) == Effect.DENY }.forEach { item ->
+        val (denyItems, allowItems) = items.partition { effectExtractor(it) == Effect.DENY }
+        denyItems.forEach { item ->
             val result = verifyItem(item)
             if (result == VerifyResult.EXPLICIT_DENY) {
                 return onMatch(item, result)
             }
         }
-        materializedItems.filter { effectExtractor(it) == Effect.ALLOW }.forEach { item ->
+        allowItems.forEach { item ->
             val result = verifyItem(item)
             if (result == VerifyResult.ALLOW) {
                 return onMatch(item, result)

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/token/TokenVerificationException.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/token/TokenVerificationException.kt
@@ -39,5 +39,5 @@ fun TokenVerificationException.toAuthorizeResult(): AuthorizeResult {
     if (this is TokenExpiredException) {
         return AuthorizeResult.TOKEN_EXPIRED
     }
-    return AuthorizeResult.deny(this.message ?: "Token Invalid")
+    return AuthorizeResult.deny("Token Invalid")
 }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/authorization/SimpleAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/authorization/SimpleAuthorizationTest.kt
@@ -32,6 +32,7 @@ import me.ahoo.cosec.permission.RolePermissionData
 import me.ahoo.cosec.policy.StatementData
 import me.ahoo.cosec.policy.action.AllActionMatcher
 import me.ahoo.cosec.policy.condition.AllConditionMatcher
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
@@ -385,5 +386,42 @@ internal class SimpleAuthorizationTest {
             .test()
             .expectNext(AuthorizeResult.IMPLICIT_DENY)
             .verifyComplete()
+    }
+
+    @Test
+    fun authorizeWhenPolicyConditionEvaluatedOnlyOnce() {
+        var matchCount = 0
+        val countingCondition = mockk<ConditionMatcher> {
+            every { match(any<Request>(), any<SecurityContext>()) } answers {
+                matchCount++
+                true
+            }
+        }
+        val globalPolicy = mockk<Policy> {
+            every { id } returns "globalPolicy"
+            every { condition } returns countingCondition
+            every { statements } returns listOf(
+                StatementData(
+                    effect = Effect.ALLOW,
+                    action = AllActionMatcher.INSTANCE,
+                ),
+            )
+        }
+        val policyRepository = mockk<PolicyRepository> {
+            every { getGlobalPolicy() } returns Mono.just(listOf(globalPolicy))
+            every { getPolicies(any()) } returns Mono.empty()
+        }
+        val permissionRepository = mockk<AppRolePermissionRepository> {
+            every { getAppRolePermission(any(), any(), any()) } returns Mono.empty()
+        }
+        val authorization = SimpleAuthorization(policyRepository, permissionRepository)
+        val request = mockk<Request>()
+
+        authorization.authorize(request, SimpleSecurityContext.anonymous())
+            .test()
+            .expectNext(AuthorizeResult.ALLOW)
+            .verifyComplete()
+
+        matchCount.assert().isEqualTo(1)
     }
 }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/token/TokenVerificationExceptionTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/token/TokenVerificationExceptionTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.token
+
+import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class TokenVerificationExceptionTest {
+
+    @Test
+    fun toAuthorizeResultWhenVerificationFailed() {
+        val exception = TokenVerificationException(
+            "com.auth0.jwt.exceptions.SignatureVerificationException: The Token's Signature resulted invalid when verified using the Algorithm: HmacSHA256"
+        )
+
+        val result = exception.toAuthorizeResult()
+
+        result.authorized.assert().isFalse()
+        result.reason.assert().isEqualTo("Token Invalid")
+    }
+
+    @Test
+    fun toAuthorizeResultWhenTokenExpired() {
+        val result = TokenExpiredException("Expired Token").toAuthorizeResult()
+
+        result.assert().isEqualTo(AuthorizeResult.TOKEN_EXPIRED)
+    }
+}

--- a/cosec-gateway-server/src/main/resources/application.yaml
+++ b/cosec-gateway-server/src/main/resources/application.yaml
@@ -40,7 +40,7 @@ cosec:
     enabled: false
   jwt:
     algorithm: hmac256
-    secret: FyN0Igd80Gas8stTavArGKOYnS9uLWGA_
+    secret: ${COSEC_JWT_SECRET:change-me-in-production}
   ip2region:
     enabled: false
   authorization:

--- a/cosec-ip2region/src/main/kotlin/me/ahoo/cosec/ip2region/Ip2RegionRequestAttributesAppender.kt
+++ b/cosec-ip2region/src/main/kotlin/me/ahoo/cosec/ip2region/Ip2RegionRequestAttributesAppender.kt
@@ -18,23 +18,26 @@ import me.ahoo.cosec.api.context.request.Request
 import me.ahoo.cosec.context.request.RequestAttributesAppender
 import org.lionsoul.ip2region.xdb.Searcher
 import org.lionsoul.ip2region.xdb.Version
-import java.io.File
+import java.io.ByteArrayInputStream
 
 const val REQUEST_ATTRIBUTES_IP_REGION_KEY = "ipRegion"
 
-class Ip2RegionRequestAttributesAppender(ip2regionFile: File = LOCAL_IP2REGION_FILE, version: Version = Version.IPv4) :
-    RequestAttributesAppender {
+class Ip2RegionRequestAttributesAppender(
+    ip2regionDb: ByteArray = loadDefaultIp2RegionDb(),
+    version: Version = Version.IPv4
+) : RequestAttributesAppender {
     companion object {
         private val log = KotlinLogging.logger {}
-        private val LOCAL_IP2REGION_FILE: File = Ip2RegionRequestAttributesAppender::class.java
-            .classLoader.getResource("ip2region.xdb").let {
-                File(it.file)
-            }
+        const val IP2REGION_DB_RESOURCE = "ip2region.xdb"
+
+        fun loadDefaultIp2RegionDb(): ByteArray =
+            Ip2RegionRequestAttributesAppender::class.java.classLoader.getResourceAsStream(IP2REGION_DB_RESOURCE)
+                ?.use { it.readBytes() }
+                ?: throw IllegalStateException("Classpath resource [$IP2REGION_DB_RESOURCE] not found.")
     }
 
     private val searcher: Searcher by lazy {
-        val dbBuffer = Searcher.loadContentFromFile(ip2regionFile.path)
-        Searcher.newWithBuffer(version, dbBuffer)
+        Searcher.newWithBuffer(version, Searcher.loadContentFromInputStream(ByteArrayInputStream(ip2regionDb)))
     }
 
     override fun append(request: Request): Request {

--- a/cosec-ip2region/src/test/kotlin/me/ahoo/cosec/ip2region/Ip2RegionRequestAttributesAppenderTest.kt
+++ b/cosec-ip2region/src/test/kotlin/me/ahoo/cosec/ip2region/Ip2RegionRequestAttributesAppenderTest.kt
@@ -17,10 +17,18 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class Ip2RegionRequestAttributesAppenderTest {
     private val ip2RegionRequestAttributesAppender = Ip2RegionRequestAttributesAppender()
+
+    @Test
+    fun loadDefaultDbIsNotEmpty() {
+        val ip2regionDb = Ip2RegionRequestAttributesAppender.loadDefaultIp2RegionDb()
+        ip2regionDb.assert().isNotNull()
+        ip2regionDb.size.assert().isGreaterThan(0)
+    }
 
     @Test
     fun append() {

--- a/cosec-jwt/src/jmh/kotlin/me/ahoo/cosec/jwt/JwtTokenConverterBenchmark.kt
+++ b/cosec-jwt/src/jmh/kotlin/me/ahoo/cosec/jwt/JwtTokenConverterBenchmark.kt
@@ -60,7 +60,7 @@ open class JwtTokenConverterBenchmark {
 
     @Setup
     fun init() {
-        algorithm = Algorithm.HMAC256("FyN0Igd80Gas8stTavArGKOYnS9uLWGA_")
+        algorithm = Algorithm.HMAC256("jwt-benchmark-secret")
         jwtTokenConverter = JwtTokenConverter(MockIdGenerator.INSTANCE, algorithm)
         jwtTokenVerifier = JwtTokenVerifier(algorithm)
         token = jwtTokenConverter.toToken(SimpleTenantPrincipal.ANONYMOUS)

--- a/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtFixture.kt
+++ b/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtFixture.kt
@@ -16,5 +16,6 @@ package me.ahoo.cosec.jwt
 import com.auth0.jwt.algorithms.Algorithm
 
 object JwtFixture {
-    var ALGORITHM = Algorithm.HMAC256("FyN0Igd80Gas8stTavArGKOYnS9uLWGA_")
+    const val TEST_JWT_SECRET = "jwt-fixture-test-secret"
+    var ALGORITHM = Algorithm.HMAC256(TEST_JWT_SECRET)
 }

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
@@ -49,7 +49,7 @@ import reactor.kotlin.core.publisher.toMono
 
 internal class ReactiveAuthorizationFilterTest {
     companion object {
-        val algorithm = Algorithm.HMAC256("FyN0Igd80Gas8stTavArGKOYnS9uLWGA_")
+        val algorithm = Algorithm.HMAC256("webflux-filter-test-secret")
         val jwtTokenConverter = JwtTokenConverter(MockIdGenerator.INSTANCE, algorithm)
         fun createAccessToken(principal: SimplePrincipal): String {
             return jwtTokenConverter.toToken(principal).accessToken

--- a/k8s/cosec-gateway-config.yaml
+++ b/k8s/cosec-gateway-config.yaml
@@ -46,7 +46,7 @@ data:
         enabled: false
       jwt:
         algorithm: hmac256
-        secret: FyN0Igd80Gas8stTavArGKOYnS9uLWGA_
+        secret: ${COSEC_JWT_SECRET:change-me-in-production}
       ip2region:
         enabled: false
       authorization:

--- a/skills/cosec-integration/SKILL.md
+++ b/skills/cosec-integration/SKILL.md
@@ -209,7 +209,7 @@ cosec:
     enabled: false          # Gateway relies on token injection from upstream
   jwt:
     algorithm: hmac256
-    secret: FyN0Igd80Gas8stTavArGKOYnS9uLWGA_
+    secret: ${COSEC_JWT_SECRET:change-me-in-production}
   authorization:
     local-policy:
       enabled: true

--- a/wiki/deep-dive/integrations/spring-cloud-gateway.md
+++ b/wiki/deep-dive/integrations/spring-cloud-gateway.md
@@ -138,7 +138,7 @@ cosec:
     enabled: false
   jwt:
     algorithm: hmac256
-    secret: FyN0Igd80Gas8stTavArGKOYnS9uLWGA_
+    secret: ${COSEC_JWT_SECRET:change-me-in-production}
   ip2region:
     enabled: false
   authorization:

--- a/wiki/deep-dive/operations/deployment.md
+++ b/wiki/deep-dive/operations/deployment.md
@@ -166,7 +166,7 @@ data:
     cosec:
       jwt:
         algorithm: hmac256
-        secret: FyN0Igd80Gas8stTavArGKOYnS9uLWGA_
+        secret: ${COSEC_JWT_SECRET:change-me-in-production}
       authorization:
         cache:
           policy:

--- a/wiki/deep-dive/operations/testing.md
+++ b/wiki/deep-dive/operations/testing.md
@@ -169,7 +169,7 @@ The `JwtFixture` object provides a shared test algorithm for JWT-based tests:
 
 ```kotlin
 object JwtFixture {
-    var ALGORITHM = Algorithm.HMAC256("FyN0Igd80Gas8stTavArGKOYnS9uLWGA_")
+    var ALGORITHM = Algorithm.HMAC256("jwt-doc-example-secret")
 }
 ```
 

--- a/wiki/zh/deep-dive/integrations/spring-cloud-gateway.md
+++ b/wiki/zh/deep-dive/integrations/spring-cloud-gateway.md
@@ -138,7 +138,7 @@ cosec:
     enabled: false
   jwt:
     algorithm: hmac256
-    secret: FyN0Igd80Gas8stTavArGKOYnS9uLWGA_
+    secret: ${COSEC_JWT_SECRET:change-me-in-production}
   ip2region:
     enabled: false
   authorization:

--- a/wiki/zh/deep-dive/operations/deployment.md
+++ b/wiki/zh/deep-dive/operations/deployment.md
@@ -166,7 +166,7 @@ data:
     cosec:
       jwt:
         algorithm: hmac256
-        secret: FyN0Igd80Gas8stTavArGKOYnS9uLWGA_
+        secret: ${COSEC_JWT_SECRET:change-me-in-production}
       authorization:
         cache:
           policy:

--- a/wiki/zh/deep-dive/operations/testing.md
+++ b/wiki/zh/deep-dive/operations/testing.md
@@ -169,7 +169,7 @@ fun authorizeWhenGlobalPolicyIsAllowAll() {
 
 ```kotlin
 object JwtFixture {
-    var ALGORITHM = Algorithm.HMAC256("FyN0Igd80Gas8stTavArGKOYnS9uLWGA_")
+    var ALGORITHM = Algorithm.HMAC256("jwt-doc-example-secret")
 }
 ```
 


### PR DESCRIPTION
## Summary

Five P1 fixes from the 2026-08-13 full-codebase analysis (TDD with red-state confirmation where unit-observable; #8 cross-layer semantics deliberately excluded pending an owner decision):

1. **fix(core)** — `TokenVerificationException.toAuthorizeResult()` returned the internal auth0 message (signature/algorithm details) as the client-facing `reason` in 401/403 bodies. Now a fixed `"Token Invalid"`; expired still maps to `TOKEN_EXPIRED`.
2. **fix(core)** — `SimpleAuthorization.evaluateDenyFirst` terminated its lazy sequence twice (deny pass + allow pass), so policy-level conditions evaluated **twice per authorization** — a policy-level rate limiter consumed 2 permits per request. Conditions now evaluate exactly once (`partition`, KDoc'd). Caveat documented: rate-limit conditions are now also evaluated for requests denied by an earlier explicit-DENY policy (uniform permit accounting).
3. **fix(cocache)** — demoting a policy from `GLOBAL` to another type now removes it from the global policy index. Previously it stayed globally active forever (fail-open).
4. **fix(ip2region)** — the xdb database now loads from the classpath as a stream. `File(URL.file)` broke every packaged-JAR deployment. Uses the real ip2region 3.3.7 API (`loadContentFromInputStream` → `LongByteArray`), javap-verified.
5. **chore(security)** — the demo JWT secret is no longer committed anywhere (app yaml, k8s manifest, test/JMH fixtures, 7 doc/skill occurrences). Deployments must set `COSEC_JWT_SECRET`; the former committed value must be treated as compromised and rotated.

## Consumer-visible changes (release notes draft)

| # | Change | Before | After |
|---|---|---|---|
| 1 | 401/403 body `reason` for token failures | internal auth0 message (info leak) | fixed `"Token Invalid"` |
| 2 | Policy-condition evaluations per authorize | 2 (rate limiter: 2 permits) | exactly 1; denied requests also consume limiter permits uniformly |
| 3 | Demoting a policy from GLOBAL | stayed globally active (fail-open) | removed from global index |
| 4 | ip2region in packaged JARs | failed at first request (unusable `jar:` File path) | stream-loaded, works |
| 5 | Committed demo secret | literal in app/k8s/fixtures/docs | env placeholder `${COSEC_JWT_SECRET:...}` + de-correlated fake fixture values |

## ⚠️ BREAKING (ip2region)

`Ip2RegionRequestAttributesAppender` constructor parameter changed `ip2regionFile: File` → `ip2regionDb: ByteArray`. In-repo callers are no-arg only. **Version decision required at release time: strict SemVer says major (5.0.0); 4.6.0 is defensible only if documented as breaking.**

## Test Plan

- [x] New regression tests, red confirmed on pre-fix code then green:
  - `TokenVerificationExceptionTest` (leaked reason → fixed reason)
  - `SimpleAuthorizationTest.authorizeWhenPolicyConditionEvaluatedOnlyOnce` (matchCount 2 → 1)
  - `RedisPolicyRepositoryTest.setPolicyWhenDemotedFromGlobal` / `setPolicyIfSystemWhenNotInGlobalIndex`
  - `Ip2RegionRequestAttributesAppenderTest.loadDefaultDbIsNotEmpty` (packaging guard)
- [x] Full `./gradlew build` — BUILD SUCCESSFUL
- [x] `./gradlew detekt` — clean (two pre-existing `detektMain` reds on untouched files are known and out of scope)
- [x] `grep -rn "FyN0Igd80Gas8stTavArGKOYnS9uLWGA_"` → 0 matches

## Follow-ups (filed, out of scope)

- cocache global-index read-modify-write race (startup-only caller today; needs a CoCache atomic-mutate API)
- Weak fallback for `COSEC_JWT_SECRET` default in the demo app (warn or fail-fast in production)
- Consolidate overlapping token test classes
- Pre-existing detektMain findings (`PolicyRepository.kt:50`, `GroupedRateLimiterConditionMatcher.kt:41`)