### PR TITLE
fix(security): close P0 filter bypass and 5 P1 findings

### DIFF
--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/RedisAppRolePermissionRepository.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/RedisAppRolePermissionRepository.kt
@@ -22,6 +22,7 @@ import me.ahoo.cosec.authorization.AppRolePermissionRepository
 import me.ahoo.cosec.permission.AppRolePermissionData
 import me.ahoo.cosec.permission.RolePermissionData
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.toMono
 
 class RedisAppRolePermissionRepository(
@@ -29,15 +30,17 @@ class RedisAppRolePermissionRepository(
     private val rolePermissionCache: RolePermissionCache
 ) : AppRolePermissionRepository {
     override fun getAppRolePermission(appId: AppId, spaceId: SpaceId, roleIds: Set<RoleId>): Mono<AppRolePermission> {
-        val appPermission = appPermissionCache[appId] ?: return Mono.empty()
-        val rolePermissions = roleIds.mapNotNull {
-            val spacedRoleId = SpacedRoleId(roleId = it, spaceId = spaceId)
-            val permissions = rolePermissionCache[spacedRoleId] ?: return@mapNotNull null
-            RolePermissionData(
-                id = it,
-                permissions = permissions,
-            )
-        }
-        return AppRolePermissionData(appPermission, rolePermissions).toMono()
+        return Mono.defer {
+            val appPermission = appPermissionCache[appId] ?: return@defer Mono.empty<AppRolePermission>()
+            val rolePermissions = roleIds.mapNotNull {
+                val spacedRoleId = SpacedRoleId(roleId = it, spaceId = spaceId)
+                val permissions = rolePermissionCache[spacedRoleId] ?: return@mapNotNull null
+                RolePermissionData(
+                    id = it,
+                    permissions = permissions,
+                )
+            }
+            AppRolePermissionData(appPermission, rolePermissions).toMono()
+        }.subscribeOn(Schedulers.boundedElastic())
     }
 }

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/RedisPolicyRepository.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/RedisPolicyRepository.kt
@@ -21,6 +21,7 @@ import me.ahoo.cosec.authorization.PolicyRepository
 import me.ahoo.cosec.cache.GlobalPolicyIndexCache.Companion.CACHE_KEY
 import me.ahoo.cosec.policy.DefaultPolicyEvaluator
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.toMono
 
 class RedisPolicyRepository(
@@ -32,21 +33,22 @@ class RedisPolicyRepository(
     }
 
     override fun getGlobalPolicy(): Mono<List<Policy>> {
-        return globalPolicyIndexCache[CACHE_KEY]
-            .orEmpty()
-            .let {
-                getPolicies(it)
-            }
+        return Mono.defer {
+            val globalPolicyIds = globalPolicyIndexCache[CACHE_KEY].orEmpty()
+            globalPolicyIds.mapNotNull { policyCache[it] }.toMono()
+        }.subscribeOn(Schedulers.boundedElastic())
     }
 
     override fun getPolicies(policyIds: Set<PolicyId>): Mono<List<Policy>> {
-        return policyIds.mapNotNull {
-            policyCache[it]
-        }.toMono()
+        return Mono.defer {
+            policyIds.mapNotNull {
+                policyCache[it]
+            }.toMono()
+        }.subscribeOn(Schedulers.boundedElastic())
     }
 
     override fun setPolicy(policy: Policy): Mono<Void> {
-        return Mono.fromRunnable {
+        return Mono.fromRunnable<Void> {
             log.info {
                 "setPolicy - policy: [${policy.id}]."
             }
@@ -60,6 +62,6 @@ class RedisPolicyRepository(
             } else if (globalPolicies != null && globalPolicies.contains(policy.id)) {
                 globalPolicyIndexCache[CACHE_KEY] = globalPolicies - policy.id
             }
-        }
+        }.subscribeOn(Schedulers.boundedElastic())
     }
 }

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/RedisAppRolePermissionRepositoryTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/RedisAppRolePermissionRepositoryTest.kt
@@ -27,6 +27,24 @@ class RedisAppRolePermissionRepositoryTest {
     }
 
     @Test
+    fun getRolePermissionsWhenRolePermissionMissing() {
+        val appPermission = AppPermissionData("appId", groups = listOf())
+        val appPermissionCache = mockk<AppPermissionCache>()
+        every { appPermissionCache.get("appId") } returns appPermission
+
+        val rolePermissionCache = mockk<RolePermissionCache>()
+        every { rolePermissionCache.get("roleId".toSpacedRoleId()) } returns null
+
+        val permissionRepository = RedisAppRolePermissionRepository(appPermissionCache, rolePermissionCache)
+        permissionRepository.getAppRolePermission("appId", "", setOf("roleId"))
+            .test()
+            .consumeNextWith {
+                assertThat(it.rolePermissions, equalTo(emptyList()))
+            }
+            .verifyComplete()
+    }
+
+    @Test
     fun getRolePermissions() {
         val permission = PermissionData(
             id = UUID.randomUUID().toString(),

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/RedisPolicyRepositoryTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/RedisPolicyRepositoryTest.kt
@@ -186,6 +186,30 @@ internal class RedisPolicyRepositoryTest {
         }
     }
 
+    @Test
+    fun getPoliciesEvaluatedPerSubscription() {
+        val otherPolicy = PolicyData(
+            id = "policyId",
+            category = "policyName",
+            name = "changed",
+            description = "policyDesc",
+            type = PolicyType.GLOBAL,
+            tenantId = "tenantId",
+            statements = listOf(),
+        )
+        val policyCache = mockk<PolicyCache>()
+        every { policyCache.get("policyId") } returnsMany listOf(policyData, otherPolicy)
+        val policyRepository = RedisPolicyRepository(mockk(), policyCache)
+        val policiesMono = policyRepository.getPolicies(setOf("policyId"))
+
+        policiesMono.test()
+            .expectNextMatches { it.single().name == "policyDesc" }
+            .verifyComplete()
+        policiesMono.test()
+            .expectNextMatches { it.single().name == "changed" }
+            .verifyComplete()
+    }
+
     private fun mockPolicyCache(): PolicyCache {
         val policyCache = mockk<PolicyCache>()
         every { policyCache.get("policyId") } returns policyData

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/RedisPolicyRepositoryTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/RedisPolicyRepositoryTest.kt
@@ -75,6 +75,19 @@ internal class RedisPolicyRepositoryTest {
     }
 
     @Test
+    fun getPoliciesWhenCacheMiss() {
+        // A policy id missing from the cache is silently dropped from the result.
+        val policyCache = mockk<PolicyCache>()
+        every { policyCache.get("policyId") } returns policyData
+        every { policyCache.get("unknownPolicyId") } returns null
+        val policyRepository = RedisPolicyRepository(mockk(), policyCache)
+        policyRepository.getPolicies(setOf("policyId", "unknownPolicyId"))
+            .test()
+            .expectNext(listOf(policyData))
+            .verifyComplete()
+    }
+
+    @Test
     fun setPolicy() {
         val globalPolicyIndexCache = mockk<GlobalPolicyIndexCache>()
         every { globalPolicyIndexCache.get(CACHE_KEY) } returns setOf()

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/InvalidRequestPathException.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/InvalidRequestPathException.kt
@@ -17,7 +17,4 @@ package me.ahoo.cosec.context.request
  * Thrown when a request path contains traversal segments (plain or percent-encoded),
  * which authorization matching must never accept.
  */
-class InvalidRequestPathException : IllegalArgumentException {
-    constructor() : super("Invalid request path.")
-    constructor(cause: Throwable) : super("Invalid request path.", cause)
-}
+class InvalidRequestPathException : IllegalArgumentException("Invalid request path.")

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/InvalidRequestPathException.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/InvalidRequestPathException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.context.request
+
+/**
+ * Thrown when a request path contains traversal segments (plain or percent-encoded),
+ * which authorization matching must never accept.
+ */
+class InvalidRequestPathException : IllegalArgumentException {
+    constructor() : super("Invalid request path.")
+    constructor(cause: Throwable) : super("Invalid request path.", cause)
+}

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/RequestPaths.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/RequestPaths.kt
@@ -35,6 +35,7 @@ object RequestPaths {
         val decodedPath = try {
             UriUtils.decode(path, Charsets.UTF_8)
         } catch (_: IllegalArgumentException) {
+            // fail-closed: a malformed percent-escape is never a safe traversal-clean path.
             return true
         }
         return decodedPath.split('/').any { it == "." || it == ".." }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/RequestPaths.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/RequestPaths.kt
@@ -29,6 +29,9 @@ object RequestPaths {
     }
 
     fun isTraversal(path: String): Boolean {
+        if ('%' !in path && '.' !in path) {
+            return false
+        }
         val decodedPath = try {
             UriUtils.decode(path, Charsets.UTF_8)
         } catch (_: IllegalArgumentException) {

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/RequestPaths.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/RequestPaths.kt
@@ -19,6 +19,9 @@ import org.springframework.web.util.UriUtils
  * Guards request paths against traversal segments before any authorization matching:
  * matching machinery percent-decodes segments, so an encoded `..` would otherwise be
  * authorized under a public wildcard pattern and normalized by the downstream container.
+ *
+ * Guarding scope is single-decode: double-encoded sequences (e.g. `%252e%252e`) decode to
+ * literals here exactly as they do in the downstream matchers, so they stay out of scope by design.
  */
 object RequestPaths {
 

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/RequestPaths.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/RequestPaths.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.context.request
+
+import org.springframework.web.util.UriUtils
+
+/**
+ * Guards request paths against traversal segments before any authorization matching:
+ * matching machinery percent-decodes segments, so an encoded `..` would otherwise be
+ * authorized under a public wildcard pattern and normalized by the downstream container.
+ */
+object RequestPaths {
+
+    fun requireSafe(path: String) {
+        if (isTraversal(path)) {
+            throw InvalidRequestPathException()
+        }
+    }
+
+    fun isTraversal(path: String): Boolean {
+        val decodedPath = try {
+            UriUtils.decode(path, Charsets.UTF_8)
+        } catch (_: IllegalArgumentException) {
+            return true
+        }
+        return decodedPath.split('/').any { it == "." || it == ".." }
+    }
+}

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/XForwardedRemoteIpResolver.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/context/request/XForwardedRemoteIpResolver.kt
@@ -44,9 +44,14 @@ abstract class XForwardedRemoteIpResolver<R>(
             return defaultRemoteIpResolver.resolve(request)
         }
 
+        if (maxTrustedIndex <= 0) {
+            return defaultRemoteIpResolver.resolve(request)
+        }
+
         val xForwardedValues = xForwardedHeaderValues[0]
             .split(DELIMITER)
             .filter { it.isNotBlank() }
+            .map { it.trim() }
             .reversed()
         if (xForwardedValues.isEmpty()) {
             return defaultRemoteIpResolver.resolve(request)

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/RequestPathsTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/RequestPathsTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.context.request
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class RequestPathsTest {
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "/public/../admin",
+            "/public/%2e%2e/admin",
+            "/public/%2E%2E/admin",
+            "/public/%2e%2e%2fadmin",
+            "/a/./b",
+            "/a/%2e/b",
+        ],
+    )
+    fun requireSafeWhenTraversal(path: String) {
+        assertThrows<InvalidRequestPathException> { RequestPaths.requireSafe(path) }
+    }
+
+    @Test
+    fun requireSafeWhenUndecodable() {
+        // A malformed escape sequence must fail closed instead of being matched verbatim.
+        assertThrows<InvalidRequestPathException> { RequestPaths.requireSafe("/a/%zz/b") }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "/",
+            "/admin",
+            "/api/users%20123",
+            "/api/users/123",
+        ],
+    )
+    fun requireSafeWhenNormal(path: String) {
+        RequestPaths.requireSafe(path)
+    }
+
+    @Test
+    fun isTraversal() {
+        RequestPaths.isTraversal("/public/../admin").assert().isTrue()
+        RequestPaths.isTraversal("/public/%2e%2e/admin").assert().isTrue()
+        RequestPaths.isTraversal("/public").assert().isFalse()
+    }
+}

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/RequestPathsTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/RequestPathsTest.kt
@@ -49,6 +49,9 @@ class RequestPathsTest {
             "/admin",
             "/api/users%20123",
             "/api/users/123",
+            // Single-decode scope by design: double-encoded segments decode to literals,
+            // in the guard exactly as in the downstream matchers.
+            "/public/%252e%252e/admin",
         ],
     )
     fun requireSafeWhenNormal(path: String) {

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/XForwardedRemoteIpResolverTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/context/request/XForwardedRemoteIpResolverTest.kt
@@ -60,4 +60,28 @@ class XForwardedRemoteIpResolverTest {
         }
         xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("ipAddress0")
     }
+
+    @Test
+    fun resolveWhenMaxTrustedIndexZero() {
+        val xForwardedRemoteIpResolver = object : XForwardedRemoteIpResolver<Request>(defaultRemoteIpResolver) {
+            override val maxTrustedIndex: Int get() = 0
+            override fun extractXForwardedHeaderValues(request: Request): List<String>? {
+                return listOf("ipAddress")
+            }
+        }
+        // maxTrustedIndex = 0 means: do not trust X-Forwarded-For at all.
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("default")
+    }
+
+    @Test
+    fun resolveWhenMaxTrustedIndexOne() {
+        val xForwardedRemoteIpResolver = object : XForwardedRemoteIpResolver<Request>(defaultRemoteIpResolver) {
+            override val maxTrustedIndex: Int get() = 1
+            override fun extractXForwardedHeaderValues(request: Request): List<String>? {
+                return listOf("ipAddress0, ipAddress1, ipAddress2")
+            }
+        }
+        // Trust exactly one hop: the rightmost entry is the one appended by the closest proxy.
+        xForwardedRemoteIpResolver.resolve(mockk()).assert().isEqualTo("ipAddress2")
+    }
 }

--- a/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/InjectSecurityContextParser.kt
+++ b/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/InjectSecurityContextParser.kt
@@ -13,12 +13,24 @@
 
 package me.ahoo.cosec.jwt
 
+import me.ahoo.cosec.api.principal.CoSecPrincipal
+import me.ahoo.cosec.api.token.AccessToken
 import me.ahoo.cosec.context.DefaultSecurityContextParser
+import me.ahoo.cosec.token.PrincipalConverter
 
 /**
  * Inject Security Context Parser .
- * WARNING: Without verify!!!
+ * WARNING: Signature is NOT verified - downstream services trust the gateway to have verified it.
+ * Time claims (exp/nbf) ARE verified: a gateway-rejected expired token must not stay valid forever here.
  *
  * @author ahoo wang
  */
-object InjectSecurityContextParser : DefaultSecurityContextParser(Jwts)
+object InjectSecurityContextParser : DefaultSecurityContextParser(InjectPrincipalConverter)
+
+private object InjectPrincipalConverter : PrincipalConverter {
+    override fun toPrincipal(accessToken: AccessToken): CoSecPrincipal {
+        val decodedAccessToken = Jwts.decode(accessToken.accessToken)
+        Jwts.verifyTimeClaims(decodedAccessToken)
+        return Jwts.toPrincipal(decodedAccessToken)
+    }
+}

--- a/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/Jwts.kt
+++ b/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/Jwts.kt
@@ -60,6 +60,8 @@ object Jwts : PrincipalConverter {
     /**
      * Verifies exp/nbf time claims without verifying the signature.
      * A token without exp is rejected: inject mode must never accept never-expiring tokens.
+     * Comparison uses millisecond precision — strictly tighter than java-jwt's verified path,
+     * which truncates now to whole seconds. Do not soften this without re-reading the design note.
      */
     fun verifyTimeClaims(decodedJwt: DecodedJWT) {
         val expiresAt = decodedJwt.expiresAt ?: throw TokenVerificationException()

--- a/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/Jwts.kt
+++ b/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/Jwts.kt
@@ -26,6 +26,9 @@ import me.ahoo.cosec.tenant.SimpleTenant
 import me.ahoo.cosec.token.PrincipalConverter
 import me.ahoo.cosec.token.SimpleTokenPrincipal
 import me.ahoo.cosec.token.SimpleTokenTenantPrincipal
+import me.ahoo.cosec.token.TokenExpiredException
+import me.ahoo.cosec.token.TokenVerificationException
+import java.util.Date
 
 /**
  * JWT utility functions.
@@ -52,6 +55,24 @@ object Jwts : PrincipalConverter {
     fun decode(token: String): DecodedJWT {
         val jwtToken = token.removeBearerPrefix()
         return jwtParser.decodeJwt(jwtToken)
+    }
+
+    /**
+     * Verifies exp/nbf time claims without verifying the signature.
+     * A token without exp is rejected: inject mode must never accept never-expiring tokens.
+     */
+    fun verifyTimeClaims(decodedJwt: DecodedJWT) {
+        val expiresAt = decodedJwt.expiresAt ?: throw TokenVerificationException()
+        if (expiresAt.before(Date())) {
+            throw TokenExpiredException()
+        }
+        verifyNotBefore(decodedJwt.notBefore)
+    }
+
+    private fun verifyNotBefore(notBefore: Date?) {
+        if (notBefore != null && notBefore.after(Date())) {
+            throw TokenVerificationException()
+        }
     }
 
     fun <T : TokenPrincipal> toPrincipal(decodedAccessToken: DecodedJWT): T {

--- a/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtsTest.kt
+++ b/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtsTest.kt
@@ -1,10 +1,15 @@
 package me.ahoo.cosec.jwt
 
+import com.auth0.jwt.JWT
 import me.ahoo.cosec.jwt.Jwts.TOKEN_PREFIX
 import me.ahoo.cosec.jwt.Jwts.removeBearerPrefix
+import me.ahoo.cosec.token.TokenExpiredException
+import me.ahoo.cosec.token.TokenVerificationException
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Date
 
 class JwtsTest {
 
@@ -16,5 +21,40 @@ class JwtsTest {
     @Test
     fun removeBearerPrefix() {
         assertThat("${TOKEN_PREFIX}token".removeBearerPrefix(), equalTo("token"))
+    }
+
+    private fun signToken(expiresAt: Date, notBefore: Date? = null): String {
+        val tokenBuilder = JWT.create().withSubject("subject").withExpiresAt(expiresAt)
+        if (notBefore != null) {
+            tokenBuilder.withNotBefore(notBefore)
+        }
+        return tokenBuilder.sign(JwtFixture.ALGORITHM)
+    }
+
+    @Test
+    fun verifyTimeClaimsWhenValid() {
+        val token = signToken(Date(System.currentTimeMillis() + 60_000))
+        Jwts.verifyTimeClaims(Jwts.decode(token))
+    }
+
+    @Test
+    fun verifyTimeClaimsWhenExpired() {
+        val token = signToken(Date(System.currentTimeMillis() - 60_000))
+        assertThrows<TokenExpiredException> { Jwts.verifyTimeClaims(Jwts.decode(token)) }
+    }
+
+    @Test
+    fun verifyTimeClaimsWhenNotBeforeInFuture() {
+        val token = signToken(
+            expiresAt = Date(System.currentTimeMillis() + 60_000),
+            notBefore = Date(System.currentTimeMillis() + 60_000),
+        )
+        assertThrows<TokenVerificationException> { Jwts.verifyTimeClaims(Jwts.decode(token)) }
+    }
+
+    @Test
+    fun verifyTimeClaimsWhenExpiresAtMissing() {
+        val token = JWT.create().withSubject("subject").sign(JwtFixture.ALGORITHM)
+        assertThrows<TokenVerificationException> { Jwts.verifyTimeClaims(Jwts.decode(token)) }
     }
 }

--- a/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtsTest.kt
+++ b/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtsTest.kt
@@ -44,6 +44,15 @@ class JwtsTest {
     }
 
     @Test
+    fun verifyTimeClaimsWhenNotBeforeInPast() {
+        val token = signToken(
+            expiresAt = Date(System.currentTimeMillis() + 60_000),
+            notBefore = Date(System.currentTimeMillis() - 60_000),
+        )
+        Jwts.verifyTimeClaims(Jwts.decode(token))
+    }
+
+    @Test
     fun verifyTimeClaimsWhenNotBeforeInFuture() {
         val token = signToken(
             expiresAt = Date(System.currentTimeMillis() + 60_000),

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/AuthorizationProperties.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/AuthorizationProperties.kt
@@ -37,6 +37,10 @@ class AuthorizationProperties(
     }
 
     class RemoteIp(
+        /**
+         * `0` ignores X-Forwarded-For entirely (directly exposed deployments);
+         * `N` trusts N proxy hops, taking the rightmost entry appended by the closest trusted proxy.
+         */
         @DefaultValue("1")
         var maxTrustedIndex: Int = 1
     )

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/AuthorizationProperties.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/AuthorizationProperties.kt
@@ -26,7 +26,8 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 @ConfigurationProperties(prefix = AuthorizationProperties.PREFIX)
 class AuthorizationProperties(
     @DefaultValue("true") override var enabled: Boolean = true,
-    var localPolicy: LocalPolicy = LocalPolicy()
+    var localPolicy: LocalPolicy = LocalPolicy(),
+    var remoteIp: RemoteIp = RemoteIp()
 ) : EnabledCapable {
     companion object {
         const val PREFIX = CoSec.COSEC_PREFIX + "authorization"
@@ -34,6 +35,11 @@ class AuthorizationProperties(
         const val LOCAL_POLICY_ENABLED = LOCAL_POLICY_PREFIX + ENABLED_SUFFIX_KEY
         const val LOCAL_POLICY_INIT_REPOSITORY = "$LOCAL_POLICY_PREFIX.init-repository"
     }
+
+    class RemoteIp(
+        @DefaultValue("1")
+        var maxTrustedIndex: Int = 1
+    )
 
     class LocalPolicy(
         @DefaultValue("false")

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecRequestParserAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecRequestParserAutoConfiguration.kt
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.server.ServerWebExchange
@@ -38,7 +39,10 @@ import org.springframework.web.server.ServerWebExchange
  */
 @AutoConfiguration
 @ConditionalOnCoSecEnabled
-class CoSecRequestParserAutoConfiguration {
+@EnableConfigurationProperties(AuthorizationProperties::class)
+class CoSecRequestParserAutoConfiguration(
+    private val authorizationProperties: AuthorizationProperties
+) {
 
     companion object {
         const val SERVLET_REMOTE_IP_RESOLVER_BEAN_NAME = "servletRemoteIpResolver"
@@ -49,12 +53,12 @@ class CoSecRequestParserAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(name = ["me.ahoo.cosec.servlet.AuthorizationFilter"])
-    class WebMvc {
+    inner class WebMvc {
 
         @Bean(SERVLET_REMOTE_IP_RESOLVER_BEAN_NAME)
         @ConditionalOnMissingBean(name = [SERVLET_REMOTE_IP_RESOLVER_BEAN_NAME])
         fun servletRemoteIpResolver(): RemoteIpResolver<HttpServletRequest> {
-            return ServletXForwardedRemoteIpResolver.TRUST_ALL
+            return ServletXForwardedRemoteIpResolver(authorizationProperties.remoteIp.maxTrustedIndex)
         }
 
         @Bean(SERVLET_REQUEST_PARSER_BEAN_NAME)
@@ -75,12 +79,12 @@ class CoSecRequestParserAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(name = ["me.ahoo.cosec.webflux.ReactiveAuthorizationFilter"])
-    class WebFlux {
+    inner class WebFlux {
 
         @Bean(REACTIVE_REMOTE_IP_RESOLVER_BEAN_NAME)
         @ConditionalOnMissingBean(name = [REACTIVE_REMOTE_IP_RESOLVER_BEAN_NAME])
         fun reactiveRemoteIpResolver(): RemoteIpResolver<ServerWebExchange> {
-            return ReactiveXForwardedRemoteIpResolver.TRUST_ALL
+            return ReactiveXForwardedRemoteIpResolver(authorizationProperties.remoteIp.maxTrustedIndex)
         }
 
         @Bean(REACTIVE_REQUEST_PARSER_BEAN_NAME)

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecRequestParserAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecRequestParserAutoConfigurationTest.kt
@@ -1,7 +1,10 @@
 package me.ahoo.cosec.spring.boot.starter.authorization
 
+import me.ahoo.cosec.servlet.ServletXForwardedRemoteIpResolver
 import me.ahoo.cosec.spring.boot.starter.authorization.CoSecRequestParserAutoConfiguration.Companion.REACTIVE_REQUEST_PARSER_BEAN_NAME
 import me.ahoo.cosec.spring.boot.starter.authorization.CoSecRequestParserAutoConfiguration.Companion.SERVLET_REQUEST_PARSER_BEAN_NAME
+import me.ahoo.cosec.webflux.ReactiveXForwardedRemoteIpResolver
+import me.ahoo.test.asserts.assert
 import org.assertj.core.api.AssertionsForInterfaceTypes
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
@@ -24,5 +27,26 @@ class CoSecRequestParserAutoConfigurationTest {
                     .hasBean(CoSecRequestParserAutoConfiguration.REACTIVE_REMOTE_IP_RESOLVER_BEAN_NAME)
                     .hasBean(REACTIVE_REQUEST_PARSER_BEAN_NAME)
             }
+    }
+
+    @Test
+    fun remoteIpResolverDefaultsToMaxTrustedIndexOne() {
+        val autoConfiguration = CoSecRequestParserAutoConfiguration(AuthorizationProperties())
+        val servletResolver =
+            autoConfiguration.WebMvc().servletRemoteIpResolver() as ServletXForwardedRemoteIpResolver
+        servletResolver.maxTrustedIndex.assert().isEqualTo(1)
+
+        val reactiveResolver =
+            autoConfiguration.WebFlux().reactiveRemoteIpResolver() as ReactiveXForwardedRemoteIpResolver
+        reactiveResolver.maxTrustedIndex.assert().isEqualTo(1)
+    }
+
+    @Test
+    fun remoteIpResolverRespectsMaxTrustedIndexProperty() {
+        val properties = AuthorizationProperties().apply { remoteIp.maxTrustedIndex = 3 }
+        val autoConfiguration = CoSecRequestParserAutoConfiguration(properties)
+        val reactiveResolver =
+            autoConfiguration.WebFlux().reactiveRemoteIpResolver() as ReactiveXForwardedRemoteIpResolver
+        reactiveResolver.maxTrustedIndex.assert().isEqualTo(3)
     }
 }

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecRequestParserAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecRequestParserAutoConfigurationTest.kt
@@ -1,3 +1,15 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package me.ahoo.cosec.spring.boot.starter.authorization
 
 import me.ahoo.cosec.servlet.ServletXForwardedRemoteIpResolver
@@ -12,13 +24,13 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 
 class CoSecRequestParserAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
+        .withUserConfiguration(
+            CoSecRequestParserAutoConfiguration::class.java,
+        )
 
     @Test
     fun contextLoads() {
         contextRunner
-            .withUserConfiguration(
-                CoSecRequestParserAutoConfiguration::class.java,
-            )
             .run { context: AssertableApplicationContext ->
                 AssertionsForInterfaceTypes.assertThat(context)
                     .hasSingleBean(CoSecRequestParserAutoConfiguration::class.java)
@@ -48,5 +60,37 @@ class CoSecRequestParserAutoConfigurationTest {
         val reactiveResolver =
             autoConfiguration.WebFlux().reactiveRemoteIpResolver() as ReactiveXForwardedRemoteIpResolver
         reactiveResolver.maxTrustedIndex.assert().isEqualTo(3)
+    }
+
+    @Test
+    fun remoteIpResolverBindsMaxTrustedIndexZero() {
+        contextRunner
+            .withPropertyValues("cosec.authorization.remote-ip.max-trusted-index=0")
+            .run { context: AssertableApplicationContext ->
+                val reactiveResolver = context.getBean(
+                    CoSecRequestParserAutoConfiguration.REACTIVE_REMOTE_IP_RESOLVER_BEAN_NAME,
+                ) as ReactiveXForwardedRemoteIpResolver
+                reactiveResolver.maxTrustedIndex.assert().isEqualTo(0)
+                val servletResolver = context.getBean(
+                    CoSecRequestParserAutoConfiguration.SERVLET_REMOTE_IP_RESOLVER_BEAN_NAME,
+                ) as ServletXForwardedRemoteIpResolver
+                servletResolver.maxTrustedIndex.assert().isEqualTo(0)
+            }
+    }
+
+    @Test
+    fun remoteIpResolverBindsMaxTrustedIndexThree() {
+        contextRunner
+            .withPropertyValues("cosec.authorization.remote-ip.max-trusted-index=3")
+            .run { context: AssertableApplicationContext ->
+                val reactiveResolver = context.getBean(
+                    CoSecRequestParserAutoConfiguration.REACTIVE_REMOTE_IP_RESOLVER_BEAN_NAME,
+                ) as ReactiveXForwardedRemoteIpResolver
+                reactiveResolver.maxTrustedIndex.assert().isEqualTo(3)
+                val servletResolver = context.getBean(
+                    CoSecRequestParserAutoConfiguration.SERVLET_REMOTE_IP_RESOLVER_BEAN_NAME,
+                ) as ServletXForwardedRemoteIpResolver
+                servletResolver.maxTrustedIndex.assert().isEqualTo(3)
+            }
     }
 }

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveInjectSecurityContextWebFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveInjectSecurityContextWebFilter.kt
@@ -14,10 +14,12 @@ package me.ahoo.cosec.webflux
 
 import me.ahoo.cosec.context.RequestSecurityContexts.setRequest
 import me.ahoo.cosec.context.SecurityContextParser
+import me.ahoo.cosec.context.request.InvalidRequestPathException
 import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.webflux.ReactiveSecurityContexts.writeSecurityContext
 import me.ahoo.cosec.webflux.ServerWebExchanges.setSecurityContext
 import org.springframework.core.Ordered
+import org.springframework.http.HttpStatus
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
@@ -44,7 +46,12 @@ class ReactiveInjectSecurityContextWebFilter(
     }
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
-        val request = requestParser.parse(exchange)
+        val request = try {
+            requestParser.parse(exchange)
+        } catch (_: InvalidRequestPathException) {
+            exchange.response.statusCode = HttpStatus.BAD_REQUEST
+            return Mono.empty()
+        }
         val securityContext = securityContextParser.ensureParse(request)
         securityContext.setRequest(request)
         exchange.mutate()

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequestParser.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveRequestParser.kt
@@ -18,6 +18,7 @@ import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.context.request.RemoteIpResolver
 import me.ahoo.cosec.context.request.RequestAttributesAppender
 import me.ahoo.cosec.context.request.RequestParser
+import me.ahoo.cosec.context.request.RequestPaths
 import me.ahoo.cosid.IdGenerator
 import me.ahoo.cosid.jvm.UuidGenerator
 import org.springframework.http.HttpHeaders
@@ -31,9 +32,11 @@ class ReactiveRequestParser(
 ) :
     RequestParser<ServerWebExchange> {
     override fun parse(request: ServerWebExchange): Request {
+        val path = request.request.path.value()
+        RequestPaths.requireSafe(path)
         var cosecRequest: Request = ReactiveRequest(
             delegate = request,
-            path = request.request.path.value(),
+            path = path,
             method = request.request.method.name(),
             remoteIp = remoteIpResolver.resolve(request),
             origin = URI.create(request.request.headers.origin.orEmpty()),

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
@@ -21,6 +21,7 @@ import me.ahoo.cosec.api.context.request.RequestIdCapable.Companion.REQUEST_ID_K
 import me.ahoo.cosec.context.RequestSecurityContexts.setRequest
 import me.ahoo.cosec.context.SecurityContextParser
 import me.ahoo.cosec.context.SimpleSecurityContext
+import me.ahoo.cosec.context.request.InvalidRequestPathException
 import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
 import me.ahoo.cosec.policy.condition.part.RegexTimeoutException
@@ -68,7 +69,12 @@ abstract class ReactiveSecurityFilter(
         exchange: ServerWebExchange,
         chain: (ServerWebExchange, Request) -> Mono<Void>
     ): Mono<Void> {
-        val request = requestParser.parse(exchange)
+        val request = try {
+            requestParser.parse(exchange)
+        } catch (_: InvalidRequestPathException) {
+            exchange.response.statusCode = HttpStatus.BAD_REQUEST
+            return Mono.empty()
+        }
         var tokenVerificationException: TokenVerificationException? = null
         val securityContext =
             try {

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
@@ -109,8 +109,8 @@ abstract class ReactiveSecurityFilter(
                     tokenVerificationException?.toAuthorizeResult() ?: authorizeResult,
                 ).then(Mono.empty())
             }.onAuthorizeError(exchange, request)
-        return authorizedExchange.flatMap { exchange ->
-            chain(exchange, request).writeSecurityContext(securityContext)
+        return authorizedExchange.flatMap { authorized ->
+            chain(authorized, request).writeSecurityContext(securityContext)
         }
     }
 

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
@@ -89,17 +89,15 @@ abstract class ReactiveSecurityFilter(
         securityContext.setRequest(request)
         exchange.setSecurityContext(securityContext)
         exchange.response.headers.trySet(REQUEST_ID_KEY, request.requestId)
-        return authorization
+        val authorizedExchange = authorization
             .authorize(request, securityContext)
-            .flatMap { authorizeResult ->
+            .flatMap<ServerWebExchange> { authorizeResult ->
                 if (authorizeResult.authorized) {
-                    exchange
+                    return@flatMap exchange
                         .mutate()
                         .principal(securityContext.principal.toMono())
                         .build()
-                        .let {
-                            return@flatMap chain(it, request).writeSecurityContext(securityContext)
-                        }
+                        .toMono()
                 }
                 val principal = securityContext.principal
                 if (!principal.authenticated) {
@@ -109,22 +107,35 @@ abstract class ReactiveSecurityFilter(
                 }
                 exchange.response.writeWithAuthorizeResult(
                     tokenVerificationException?.toAuthorizeResult() ?: authorizeResult,
-                )
-            }.onErrorResume(TooManyRequestsException::class.java) { _ ->
-                exchange.response.statusCode = HttpStatus.TOO_MANY_REQUESTS
-                exchange.response.writeWithAuthorizeResult(AuthorizeResult.TOO_MANY_REQUESTS)
-            }.onErrorResume(RegexTimeoutException::class.java) { _ ->
-                // A regex condition exceeding its time budget (ReDoS guard) is an expected, fail-closed
-                // authorization outcome -> deny, not a 5xx server error (which would invite client retries).
-                exchange.response.statusCode = HttpStatus.FORBIDDEN
-                exchange.response.writeWithAuthorizeResult(AuthorizeResult.IMPLICIT_DENY)
-            }.onErrorResume { cause ->
-                log.error(cause) {
-                    "Unexpected error during authorization of request [${request.path}] [${request.method}]."
-                }
-                exchange.response.statusCode = HttpStatus.INTERNAL_SERVER_ERROR
-                exchange.response.writeWithAuthorizeResult(AuthorizeResult.IMPLICIT_DENY)
+                ).then(Mono.empty())
+            }.onAuthorizeError(exchange, request)
+        return authorizedExchange.flatMap { exchange ->
+            chain(exchange, request).writeSecurityContext(securityContext)
+        }
+    }
+
+    private fun Mono<ServerWebExchange>.onAuthorizeError(
+        exchange: ServerWebExchange,
+        request: Request
+    ): Mono<ServerWebExchange> {
+        return onErrorResume(TooManyRequestsException::class.java) { _ ->
+            exchange.response.statusCode = HttpStatus.TOO_MANY_REQUESTS
+            exchange.response.writeWithAuthorizeResult(AuthorizeResult.TOO_MANY_REQUESTS)
+                .then(Mono.empty())
+        }.onErrorResume(RegexTimeoutException::class.java) { _ ->
+            // A regex condition exceeding its time budget (ReDoS guard) is an expected, fail-closed
+            // authorization outcome -> deny, not a 5xx server error (which would invite client retries).
+            exchange.response.statusCode = HttpStatus.FORBIDDEN
+            exchange.response.writeWithAuthorizeResult(AuthorizeResult.IMPLICIT_DENY)
+                .then(Mono.empty())
+        }.onErrorResume { cause ->
+            log.error(cause) {
+                "Unexpected error during authorization of request [${request.path}] [${request.method}]."
             }
+            exchange.response.statusCode = HttpStatus.INTERNAL_SERVER_ERROR
+            exchange.response.writeWithAuthorizeResult(AuthorizeResult.IMPLICIT_DENY)
+                .then(Mono.empty())
+        }
     }
 
     fun ServerHttpResponse.writeWithAuthorizeResult(authorizeResult: AuthorizeResult): Mono<Void> {

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveXForwardedRemoteIpResolver.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveXForwardedRemoteIpResolver.kt
@@ -16,7 +16,7 @@ package me.ahoo.cosec.webflux
 import me.ahoo.cosec.context.request.XForwardedRemoteIpResolver
 import org.springframework.web.server.ServerWebExchange
 
-class ReactiveXForwardedRemoteIpResolver(override val maxTrustedIndex: Int = Int.MAX_VALUE) :
+class ReactiveXForwardedRemoteIpResolver(override val maxTrustedIndex: Int = 1) :
     XForwardedRemoteIpResolver<ServerWebExchange>(ReactiveRemoteIpResolver) {
     companion object {
         val TRUST_ALL = ReactiveXForwardedRemoteIpResolver(Int.MAX_VALUE)

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
@@ -342,4 +342,21 @@ internal class ReactiveAuthorizationFilterTest {
             exchange.response.writeWith(any())
         }
     }
+
+    @Test
+    fun filterWhenInvalidPath() {
+        val authorization = mockk<Authorization>()
+        val filter = ReactiveAuthorizationFilter(
+            InjectSecurityContextParser,
+            ReactiveRequestParser(ReactiveRemoteIpResolver),
+            authorization,
+        )
+        val serverRequest = MockServerHttpRequest.get("/public/../admin").build()
+        val exchange = MockServerWebExchange.builder(serverRequest).build()
+        val filterChain = mockk<WebFilterChain>()
+        filter.filter(exchange, filterChain).block()
+
+        exchange.response.statusCode.assert().isEqualTo(HttpStatus.BAD_REQUEST)
+        verify(exactly = 0) { authorization.authorize(any(), any()) }
+    }
 }

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
@@ -380,5 +380,7 @@ internal class ReactiveAuthorizationFilterTest {
 
         exchange.response.statusCode.assert().isEqualTo(HttpStatus.BAD_REQUEST)
         verify(exactly = 0) { authorization.authorize(any(), any()) }
+        // A traversal path must not reach the filter chain.
+        verify(exactly = 0) { filterChain.filter(any()) }
     }
 }

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
@@ -344,6 +344,28 @@ internal class ReactiveAuthorizationFilterTest {
     }
 
     @Test
+    fun filterWhenDownstreamErrorPropagates() {
+        val authorization = mockk<Authorization> {
+            every { authorize(any(), any()) } returns AuthorizeResult.ALLOW.toMono()
+        }
+        val filter = ReactiveAuthorizationFilter(
+            InjectSecurityContextParser,
+            ReactiveRequestParser(ReactiveRemoteIpResolver),
+            authorization,
+        )
+        val serverRequest = MockServerHttpRequest.get("/path").build()
+        val exchange = MockServerWebExchange.builder(serverRequest).build()
+        val downstreamError = IllegalStateException("downstream boom")
+        val filterChain = WebFilterChain { Mono.error<Void>(downstreamError) }
+
+        val thrown = runCatching { filter.filter(exchange, filterChain).block() }.exceptionOrNull()
+        // Errors from the downstream handler must reach Spring's error handling, not be
+        // rewritten into a 500 "Implicit Deny" by the authorization filter.
+        thrown.assert().isEqualTo(downstreamError)
+        exchange.response.statusCode.assert().isNull()
+    }
+
+    @Test
     fun filterWhenInvalidPath() {
         val authorization = mockk<Authorization>()
         val filter = ReactiveAuthorizationFilter(

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveInjectSecurityContextWebFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveInjectSecurityContextWebFilterTest.kt
@@ -26,6 +26,9 @@ import me.ahoo.cosec.webflux.ServerWebExchanges.setSecurityContext
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
@@ -62,5 +65,20 @@ internal class ReactiveInjectSecurityContextWebFilterTest {
         verify {
             exchange.setSecurityContext(any())
         }
+    }
+
+    @Test
+    fun filterWhenInvalidPath() {
+        val filter = ReactiveInjectSecurityContextWebFilter(
+            ReactiveRequestParser(ReactiveRemoteIpResolver),
+            InjectSecurityContextParser
+        )
+        val serverRequest = MockServerHttpRequest.get("/public/../admin").build()
+        val exchange = MockServerWebExchange.builder(serverRequest).build()
+        val filterChain = mockk<WebFilterChain>()
+        filter.filter(exchange, filterChain).block()
+
+        exchange.response.statusCode.assert().isEqualTo(HttpStatus.BAD_REQUEST)
+        verify(exactly = 0) { filterChain.filter(any()) }
     }
 }

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestParserTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveRequestParserTest.kt
@@ -13,13 +13,17 @@
 
 package me.ahoo.cosec.webflux
 
+import me.ahoo.cosec.context.request.InvalidRequestPathException
 import me.ahoo.cosec.context.request.XForwardedRemoteIpResolver.Companion.X_FORWARDED_FOR
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpMethod
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.server.MockServerWebExchange
 import java.net.InetSocketAddress
+import java.net.URI
 
 internal class ReactiveRequestParserTest {
 
@@ -33,5 +37,15 @@ internal class ReactiveRequestParserTest {
         val request = requestParser.parse(serverWebExchange)
         assertThat(request.path, `is`("/path"))
         assertThat(request.method, `is`("GET"))
+    }
+
+    @Test
+    fun parseWhenTraversalPath() {
+        // MockServerHttpRequest.get(String) treats the string as a URI template and re-encodes
+        // '%' to '%25'; a pre-encoded URI mirrors what a real server delivers to the parser.
+        val serverRequest = MockServerHttpRequest.method(HttpMethod.GET, URI.create("/public/%2e%2e/admin")).build()
+        val exchange = MockServerWebExchange.builder(serverRequest).build()
+        val parser = ReactiveRequestParser(ReactiveRemoteIpResolver)
+        assertThrows<InvalidRequestPathException> { parser.parse(exchange) }
     }
 }

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveXForwardedRemoteIpResolverTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveXForwardedRemoteIpResolverTest.kt
@@ -24,7 +24,8 @@ class ReactiveXForwardedRemoteIpResolverTest {
     @Test
     fun extractXForwardedHeaderValues() {
         val xForwardedRemoteIpResolver = ReactiveXForwardedRemoteIpResolver()
-        xForwardedRemoteIpResolver.maxTrustedIndex.assert().isEqualTo(Int.MAX_VALUE)
+        // The default trusts exactly one hop (rightmost entry); use TRUST_ALL for the old trust-all behavior.
+        xForwardedRemoteIpResolver.maxTrustedIndex.assert().isEqualTo(1)
         val serverRequest = MockServerHttpRequest.get("")
             .header(X_FORWARDED_FOR, "localhost")
         val serverWebExchange = MockServerWebExchange.from(serverRequest)

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AuthorizationFilter.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AuthorizationFilter.kt
@@ -70,11 +70,13 @@ class AuthorizationFilter(
             } catch (tooManyRequestsException: TooManyRequestsException) {
                 response.status = HttpStatus.TOO_MANY_REQUESTS.value()
                 httpServletResponse.writeWithAuthorizeResult(AuthorizeResult.TOO_MANY_REQUESTS)
+                return
             } catch (regexTimeoutException: RegexTimeoutException) {
                 // A regex condition exceeding its time budget (ReDoS guard) is an expected, fail-closed
                 // authorization outcome -> deny, not a 5xx server error (which would invite client retries).
                 httpServletResponse.status = HttpStatus.FORBIDDEN.value()
                 httpServletResponse.writeWithAuthorizeResult(AuthorizeResult.IMPLICIT_DENY)
+                return
             } catch (cause: Exception) {
                 log.error(cause) {
                     "Unexpected error during authorization of request [${httpServletRequest.servletPath}] [${httpServletRequest.method}]."

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AuthorizationFilter.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AuthorizationFilter.kt
@@ -24,6 +24,7 @@ import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.context.SecurityContextHolder
 import me.ahoo.cosec.context.SecurityContextParser
+import me.ahoo.cosec.context.request.InvalidRequestPathException
 import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
 import me.ahoo.cosec.policy.condition.part.RegexTimeoutException
@@ -67,6 +68,9 @@ class AuthorizationFilter(
                 if (!authorize(httpServletRequest, httpServletResponse)) {
                     return
                 }
+            } catch (_: InvalidRequestPathException) {
+                httpServletResponse.status = HttpStatus.BAD_REQUEST.value()
+                return
             } catch (tooManyRequestsException: TooManyRequestsException) {
                 response.status = HttpStatus.TOO_MANY_REQUESTS.value()
                 httpServletResponse.writeWithAuthorizeResult(AuthorizeResult.TOO_MANY_REQUESTS)

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilter.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilter.kt
@@ -18,12 +18,15 @@ import jakarta.servlet.ServletException
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.context.RequestSecurityContexts.setRequest
 import me.ahoo.cosec.context.SecurityContextHolder
 import me.ahoo.cosec.context.SecurityContextParser
+import me.ahoo.cosec.context.request.InvalidRequestPathException
 import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.servlet.ServletRequests.setSecurityContext
+import org.springframework.http.HttpStatus
 import java.io.IOException
 
 /**
@@ -48,19 +51,27 @@ class InjectSecurityContextFilter(
         // The injected SecurityContext is bound to the current (pooled) thread; remove it once the request
         // completes so it cannot bleed into the next request served by the same worker thread.
         try {
-            tryInjectSecurityContext(servletRequest)
-            filterChain.doFilter(servletRequest, servletResponse)
+            if (tryInjectSecurityContext(servletRequest)) {
+                filterChain.doFilter(servletRequest, servletResponse)
+            } else {
+                (servletResponse as HttpServletResponse).status = HttpStatus.BAD_REQUEST.value()
+            }
         } finally {
             SecurityContextHolder.remove()
         }
     }
 
-    private fun tryInjectSecurityContext(servletRequest: ServletRequest) {
+    private fun tryInjectSecurityContext(servletRequest: ServletRequest): Boolean {
         val httpServletRequest = servletRequest as HttpServletRequest
-        val request = requestParser.parse(servletRequest)
+        val request = try {
+            requestParser.parse(servletRequest)
+        } catch (_: InvalidRequestPathException) {
+            return false
+        }
         val securityContext: SecurityContext = securityContextParser.ensureParse(request)
         securityContext.setRequest(request)
         SecurityContextHolder.setContext(securityContext)
         httpServletRequest.setSecurityContext(securityContext)
+        return true
     }
 }

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/ServletRequestParser.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/ServletRequestParser.kt
@@ -18,6 +18,7 @@ import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.context.request.RemoteIpResolver
 import me.ahoo.cosec.context.request.RequestAttributesAppender
 import me.ahoo.cosec.context.request.RequestParser
+import me.ahoo.cosec.context.request.RequestPaths
 import me.ahoo.cosid.IdGenerator
 import me.ahoo.cosid.jvm.UuidGenerator
 import org.springframework.http.HttpHeaders
@@ -34,6 +35,7 @@ class ServletRequestParser(
     private val idGenerator: IdGenerator = UuidGenerator.INSTANCE
 ) : RequestParser<HttpServletRequest> {
     override fun parse(request: HttpServletRequest): Request {
+        RequestPaths.requireSafe(request.servletPath)
         var cosecRequest: Request = CoSecServletRequest(
             delegate = request,
             path = request.servletPath,

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/ServletXForwardedRemoteIpResolver.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/ServletXForwardedRemoteIpResolver.kt
@@ -16,7 +16,7 @@ package me.ahoo.cosec.servlet
 import jakarta.servlet.http.HttpServletRequest
 import me.ahoo.cosec.context.request.XForwardedRemoteIpResolver
 
-class ServletXForwardedRemoteIpResolver(override val maxTrustedIndex: Int = Int.MAX_VALUE) :
+class ServletXForwardedRemoteIpResolver(override val maxTrustedIndex: Int = 1) :
     XForwardedRemoteIpResolver<HttpServletRequest>(ServletRemoteIpResolver) {
     companion object {
         val TRUST_ALL = ServletXForwardedRemoteIpResolver(Int.MAX_VALUE)

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
@@ -202,6 +202,8 @@ internal class AuthorizationFilterTest {
             servletResponse.outputStream.write(any() as ByteArray)
             servletResponse.outputStream.flush()
         }
+        // The request was denied by the rate limiter, so it must not reach the filter chain.
+        verify(exactly = 0) { filterChain.doFilter(any(), any()) }
     }
 
     @Test
@@ -246,6 +248,8 @@ internal class AuthorizationFilterTest {
         }
         // A ReDoS-guard trip is an expected deny, not a server error, and must clean up the context.
         assertThat(SecurityContextHolder.context, nullValue())
+        // The request was denied by the ReDoS guard, so it must not reach the filter chain.
+        verify(exactly = 0) { filterChain.doFilter(any(), any()) }
     }
 
     @Test

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
@@ -334,4 +334,28 @@ internal class AuthorizationFilterTest {
             servletResponse.outputStream.flush()
         }
     }
+
+    @Test
+    fun doFilterWhenInvalidPath() {
+        val authorization = mockk<Authorization>()
+        val filter = AuthorizationFilter(
+            InjectSecurityContextParser,
+            authorization,
+            ServletRequestParser(ServletRemoteIpResolver),
+        )
+        val servletRequest = mockk<HttpServletRequest> {
+            every { servletPath } returns "/public/../admin"
+        }
+        val servletResponse = mockk<HttpServletResponse> {
+            every { status = HttpStatus.BAD_REQUEST.value() } returns Unit
+        }
+        val filterChain = mockk<FilterChain>()
+        filter.doFilter(servletRequest, servletResponse, filterChain)
+
+        verify {
+            servletResponse.status = HttpStatus.BAD_REQUEST.value()
+        }
+        verify(exactly = 0) { filterChain.doFilter(any(), any()) }
+        verify(exactly = 0) { authorization.authorize(any(), any()) }
+    }
 }

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
@@ -119,6 +119,8 @@ internal class AuthorizationFilterTest {
         filter.doFilter(servletRequest, servletResponse, filterChain)
         // A denied request must not leave its security context bound to the (pooled) request thread.
         assertThat(SecurityContextHolder.context, nullValue())
+        // A denied request must not reach the filter chain.
+        verify(exactly = 0) { filterChain.doFilter(any(), any()) }
     }
 
     @Test
@@ -290,6 +292,7 @@ internal class AuthorizationFilterTest {
             servletResponse.outputStream.write(any() as ByteArray)
             servletResponse.outputStream.flush()
         }
+        verify(exactly = 0) { filterChain.doFilter(any(), any()) }
     }
 
     @Test

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/InjectSecurityContextFilterTest.kt
@@ -15,8 +15,10 @@ package me.ahoo.cosec.servlet
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.api.principal.CoSecPrincipal
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
@@ -28,6 +30,7 @@ import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 
 internal class InjectSecurityContextFilterTest {
 
@@ -76,5 +79,25 @@ internal class InjectSecurityContextFilterTest {
             every { doFilter(request, any()) } returns Unit
         }
         filter.doFilter(request, mockk(), filterChain)
+    }
+
+    @Test
+    fun doFilterWhenInvalidPath() {
+        val filter =
+            InjectSecurityContextFilter(ServletRequestParser(ServletRemoteIpResolver), InjectSecurityContextParser)
+        val request = mockk<HttpServletRequest> {
+            every { servletPath } returns "/public/../admin"
+        }
+        val response = mockk<HttpServletResponse> {
+            every { status = HttpStatus.BAD_REQUEST.value() } returns Unit
+        }
+        val filterChain = mockk<FilterChain>()
+        filter.doFilter(request, response, filterChain)
+
+        verify {
+            response.status = HttpStatus.BAD_REQUEST.value()
+        }
+        verify(exactly = 0) { filterChain.doFilter(any(), any()) }
+        assertThat(SecurityContextHolder.context, nullValue())
     }
 }

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/ServletRequestParserTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/ServletRequestParserTest.kt
@@ -17,9 +17,11 @@ import io.mockk.every
 import io.mockk.mockk
 import jakarta.servlet.http.HttpServletRequest
 import me.ahoo.cosec.api.context.request.RequestIdCapable
+import me.ahoo.cosec.context.request.InvalidRequestPathException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpHeaders
 
 internal class ServletRequestParserTest {
@@ -38,5 +40,14 @@ internal class ServletRequestParserTest {
         val request = servletRequestParser.parse(servletRequest)
         assertThat(request.path, equalTo("/path"))
         assertThat(request.method, equalTo("GET"))
+    }
+
+    @Test
+    fun parseWhenTraversalPath() {
+        val servletRequest = mockk<HttpServletRequest> {
+            every { servletPath } returns "/public/../admin"
+        }
+        val parser = ServletRequestParser(ServletRemoteIpResolver)
+        assertThrows<InvalidRequestPathException> { parser.parse(servletRequest) }
     }
 }

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/ServletXForwardedRemoteIpResolverTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/ServletXForwardedRemoteIpResolverTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.servlet
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class ServletXForwardedRemoteIpResolverTest {
+
+    @Test
+    fun defaultMaxTrustedIndex() {
+        val xForwardedRemoteIpResolver = ServletXForwardedRemoteIpResolver()
+        // The default trusts exactly one hop (rightmost entry); use TRUST_ALL for the old trust-all behavior.
+        xForwardedRemoteIpResolver.maxTrustedIndex.assert().isEqualTo(1)
+    }
+}


### PR DESCRIPTION
## Security fixes (P0/P1)

Six security defects across the request-authorization path.

- **P0-1 — Servlet filter bypass (`cosec-webmvc`).** `AuthorizationFilter` continued the filter chain after rate-limit and regex-timeout denials, so a denied request still reached the downstream servlet. Denial now terminates the chain.
- **P1-3 — Path traversal in policy matching (`cosec-core`, `cosec-webmvc`, `cosec-webflux`).** Action matchers percent-decode path segments, so an encoded `..` could match a permissive public wildcard and then be normalized by the container into a protected path. New `RequestPaths.requireSafe` rejects plain and percent-encoded traversal segments (and undecodable paths) before matching; inject filters map `InvalidRequestPathException` to 400.
- **P1-7 — Over-broad reactive error mapping (`cosec-webflux`).** `ReactiveSecurityFilter` mapped errors from the whole pipeline, converting downstream handler failures into authorization responses. Mapping is now scoped to the authorize stage only.
- **P1-2 — Unbounded `X-Forwarded-For` trust (`cosec-core`, `cosec-spring-boot-starter`).** The resolver trusted the leftmost XFF entry, which is fully client-controlled, letting callers spoof source IP for IP-based conditions. Trust is now bounded by `maxTrustedIndex`, defaulting to a single hop. **Breaking — see below.**
- **P1-5 — Blocking I/O on the event loop (`cosec-cocache`).** `RedisPolicyRepository` and `RedisAppRolePermissionRepository` performed blocking cache reads eagerly during assembly, running them on the caller's (event-loop) thread. Reads are deferred so they execute on `boundedElastic`.
- **P1-8 — Unverified token lifetime in inject mode (`cosec-jwt`).** `InjectSecurityContextParser` decoded tokens without checking time claims, so expired/not-yet-valid tokens were accepted at the trusted-gateway boundary. Now verifies `exp`/`nbf` via `Jwts.verifyTimeClaims`; tokens without `exp` are now rejected in this mode.

## Breaking change: X-Forwarded-For trust default

`XForwardedRemoteIpResolver` no longer trusts the leftmost XFF entry. It now honours `maxTrustedIndex`, exposed as `cosec.authorization.remote-ip.max-trusted-index` and **defaulting to `1`** (trust one proxy hop, i.e. the rightmost entry appended by the closest trusted proxy). Multiple XFF headers are discarded and fall back to the socket address.

| Deployment | Impact | Action |
|---|---|---|
| No proxy, or exactly 1 trusted proxy | None | No change needed |
| N (>1) trusted proxies | `remoteIp` resolves to the closest proxy instead of the client | Set `cosec.authorization.remote-ip.max-trusted-index: N` |
| Directly internet-exposed | Single self-reported XFF entry still honored (no worse than before) | Set `0` to ignore XFF entirely |

Programmatic note: no-arg construction of `ServletXForwardedRemoteIpResolver`/`ReactiveXForwardedRemoteIpResolver` changed from TRUST_ALL to one-hop; the `TRUST_ALL` constants remain available for explicit use.

## Other behavior changes (upgrade-visible)

- **Inject mode now requires `exp`** — tokens without `exp`, expired, or not-yet-valid are rejected. `JwtTokenConverter`-issued tokens always carry `exp`; only custom issuers of `exp`-less tokens are affected.
- **Paths with `.`/`..` segments (plain or encoded) now return a bodyless 400** — rare legitimate literal dot-segment URLs (e.g. some file-serving APIs) are rejected.
- **Reactive downstream errors now propagate their real status** (404/502 etc.) instead of being rewritten to `500 "Implicit Deny"` — ops dashboards/alerts keyed on the old rewrite need adjusting.

## Release recommendation

Ship as **4.7.0 (minor)**, not a patch: the XFF default change and the three behavior changes above are upgrade-visible. Pin the migration table at the top of the release notes.

## Verification

- `./gradlew detekt` — 0 violations across all modules
- `./gradlew test` — full suite passes (331 tests incl. 30+ new; 1 pre-existing unrelated skip)
- Every commit TDD'd; intermediate commits build and test cleanly
- Four review layers passed: per-task spec review, per-task quality review, full-branch independent review, delta + merge-readiness re-review — no open Critical/Important findings

## Out-of-scope follow-ups

- Register a verified-path `exp` check so inject-mode and full-verification modes share one time-claim code path rather than duplicating the logic (the verified path currently also accepts `exp`-less tokens).
- Reactive/servlet parity gaps remain in the filter implementations (error handling and chain-termination semantics are structurally divergent and were only narrowly aligned here).
- The path guard rejects traversal segments but does not reject matrix parameters (`;`), which can still alter container-side path interpretation.
- P2 candidate (pre-existing): malformed `Origin`/`Referer` headers make `URI.create` throw → attacker-triggerable 500/log noise.