### PR TITLE
fix: close P1-4 by contract, require exp on verified path, normalize method case

### DIFF
--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/principal/RoleCapable.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/principal/RoleCapable.kt
@@ -35,6 +35,9 @@ interface RoleIdCapable {
  *
  * @see RoleIdCapable
  * @see SpaceIdCapable
+ *
+ * Cache-key representation only: role IDs never contain '@' (see [RoleCapable.roles]),
+ * so the `roleId@spaceId` encoding is unambiguous.
  */
 data class SpacedRoleId(
     override val roleId: RoleId,
@@ -85,6 +88,11 @@ data class SpacedRoleId(
 interface RoleCapable {
     /**
      * The set of role IDs assigned to this principal.
+     *
+     * Contract: role IDs are globally unique and never contain '@'.
+     * Role permissions are stored per space under (roleId, spaceId); the request's
+     * spaceId selects the evaluation context—it chooses among defined scopes,
+     * it does not expand grants.
      *
      * @return Set of role identifiers
      */

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/AbstractActionMatcher.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/AbstractActionMatcher.kt
@@ -30,7 +30,7 @@ abstract class AbstractActionMatcher(
             if (methodConfiguration.isString) {
                 return setOf(methodConfiguration.asString().uppercase())
             }
-            return methodConfiguration.asStringList().toSet()
+            return methodConfiguration.asStringList().map { it.uppercase() }.toSet()
         }
     }
 

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/action/AllActionMatcherTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/policy/action/AllActionMatcherTest.kt
@@ -44,4 +44,20 @@ internal class AllActionMatcherTest {
         }
         assertThat(allActionMatcher.match(postRequest, mockk()), `is`(false))
     }
+
+    @Test
+    fun matchMethodListLowerCase() {
+        val allActionMatcher =
+            AllActionMatcherFactory().create(
+                mapOf(ACTION_MATCHER_METHOD_KEY to listOf("get", "post")).asConfiguration()
+            )
+        val getRequest = mockk<Request> {
+            every { method } returns "GET"
+        }
+        assertThat(allActionMatcher.match(getRequest, mockk()), `is`(true))
+        val putRequest = mockk<Request> {
+            every { method } returns "PUT"
+        }
+        assertThat(allActionMatcher.match(putRequest, mockk()), `is`(false))
+    }
 }

--- a/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifier.kt
+++ b/cosec-jwt/src/main/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifier.kt
@@ -37,7 +37,9 @@ import me.ahoo.cosec.token.TokenVerifier
 class JwtTokenVerifier(
     private val algorithm: Algorithm
 ) : TokenVerifier {
-    private val jwtVerifier: JWTVerifier = JWT.require(algorithm).build()
+    private val jwtVerifier: JWTVerifier = JWT.require(algorithm)
+        .withClaimPresence("exp")
+        .build()
 
     @Suppress("TooGenericExceptionCaught")
     private fun verify(accessToken: String): DecodedJWT {

--- a/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifierTest.kt
+++ b/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifierTest.kt
@@ -48,9 +48,11 @@ class JwtTokenVerifierTest {
     @Test
     fun verifyWhenExpiresAtMissing() {
         val token = JWT.create().withSubject("subject").sign(JwtFixture.ALGORITHM)
-        assertThrows(TokenVerificationException::class.java) {
+        val thrown = assertThrows(TokenVerificationException::class.java) {
             jwtTokenVerifier.verify<TokenPrincipal>(SimpleAccessToken(token))
         }
+        // Missing exp is an invalid token, not an expired one — pin the mapping.
+        assertFalse(thrown is TokenExpiredException)
     }
 
     @Test

--- a/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifierTest.kt
+++ b/cosec-jwt/src/test/kotlin/me/ahoo/cosec/jwt/JwtTokenVerifierTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.cosec.api.token.CompositeToken
 import me.ahoo.cosec.api.token.TokenPrincipal
 import me.ahoo.cosec.api.token.TokenTenantPrincipal
 import me.ahoo.cosec.principal.SimpleTenantPrincipal
+import me.ahoo.cosec.token.SimpleAccessToken
 import me.ahoo.cosec.token.SimpleCompositeToken
 import me.ahoo.cosec.token.TokenExpiredException
 import me.ahoo.cosec.token.TokenVerificationException
@@ -42,6 +43,14 @@ class JwtTokenVerifierTest {
         val token: CompositeToken = jwtTokenConverter.toToken(SimpleTenantPrincipal.ANONYMOUS)
         val principal: TokenTenantPrincipal = jwtTokenVerifier.verify(token)
         assertThat(principal.name, equalTo(CoSecPrincipal.ANONYMOUS_ID))
+    }
+
+    @Test
+    fun verifyWhenExpiresAtMissing() {
+        val token = JWT.create().withSubject("subject").sign(JwtFixture.ALGORITHM)
+        assertThrows(TokenVerificationException::class.java) {
+            jwtTokenVerifier.verify<TokenPrincipal>(SimpleAccessToken(token))
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Three small contract/security hardenings following the P0/P1 batch in #832.

- **P1-4 closure (docs only)** — the space-scope trust model is now an explicit contract on `RoleCapable.roles`: role IDs are globally unique and never contain `@`; role permissions are stored per space under `(roleId, spaceId)`; the request's `spaceId` selects the evaluation context (a selector among defined scopes, never a grant expander). With these domain constraints the previously reported client-controlled-spaceId finding is by design, not a defect.
- **Require `exp` on the verified path (`cosec-jwt`)** — `JwtTokenVerifier` now uses `withClaimPresence("exp")`. Previously a signed token without `exp` passed signature verification and never expired (java-jwt only checks `exp` when present). Symmetric with inject mode's `verifyTimeClaims` (shipped in 4.7.0). Missing `exp` maps to `TokenVerificationException`, not `TokenExpiredException` (pinned by test).
- **Uppercase method list entries (`cosec-core`)** — `AbstractActionMatcher` uppercased the single-string `method` form but not list entries, so `"method": ["delete"]` never matched `DELETE` requests — lowercase **DENY rules silently never fired** (fail-open). List entries are now normalized.

## Behavior changes (release notes)

1. Signed tokens without an `exp` claim are now rejected on the verified path. `JwtTokenConverter`-minted tokens always carry `exp`; only custom issuers of `exp`-less tokens are affected.
2. Policy action matchers with lowercase `method` lists now match as written. Previously such rules never matched (ALLOW silently locked out / DENY silently ineffective); deployments relying on that broken behavior should review their policy definitions.

## Verification

- `./gradlew detekt` — clean
- `./gradlew test` — 338 passed / 0 failed / 1 skipped (pre-existing, unrelated)
- Both fixes verified by mutation testing (tests fail when the fix is reverted)
- Per-task code review + final holistic review passed

## Follow-ups noted (not in this PR)

- Condition-side `${request.method}` extraction has no case normalization on either side (`PartExtractor.kt:57`) — unconfirmed issue; per TDD-first policy it warrants investigation with a red test if a concrete lowercase-condition scenario emerges.