### PR TITLE
docs(skills): fix factual errors and align all examples with source code

### DIFF
--- a/skills/cosec-custom-matcher/SKILL.md
+++ b/skills/cosec-custom-matcher/SKILL.md
@@ -13,7 +13,7 @@ Policy matching has two sides:
 - **ActionMatcher** — determines if a request's action (path + method) matches a policy pattern
 - **ConditionMatcher** — determines if contextual conditions are met (user attributes, request properties, etc.)
 
-Both matcher interfaces live in `cosec-api` (`me.ahoo.cosec.api.policy`); the factories live in `cosec-core` (`me.ahoo.cosec.policy.action` / `me.ahoo.cosec.policy.condition`) and are created by factory classes registered via SPI.
+Both extend `RequestMatcher`. The matcher interfaces live in `cosec-api` (`me.ahoo.cosec.api.policy`); the factory interfaces live in `cosec-core` (`me.ahoo.cosec.policy.action` / `me.ahoo.cosec.policy.condition`), and factory implementations are discovered via Java SPI (ServiceLoader).
 
 ```
 Policy
@@ -244,9 +244,10 @@ For reference, here are all built-in types:
 
 | Type | Description | Key Config |
 |------|-------------|------------|
+| `all` | Match all (the default when `condition` is omitted) | — |
 | `authenticated` | User must be logged in | — |
 | `inRole` | User must have role | `value`: role name |
-| `inTenant` | Must be from tenant | `value`: tenant ID |
+| `inTenant` | Must be from tenant type | `value`: `default` / `user` / `platform` |
 | `eq` | Exact match | `part`, `value` |
 | `contains` | Substring match | `part`, `value` |
 | `startsWith` | Prefix match | `part`, `value` |
@@ -259,6 +260,8 @@ For reference, here are all built-in types:
 | `ognl` | OGNL expression | `expression` |
 | `rateLimiter` | Rate limiting | `permitsPerSecond` |
 | `groupedRateLimiter` | Grouped rate limit | `part`, `permitsPerSecond`, `expireAfterAccessSecond` |
+
+`negate: true` is accepted by **every** condition matcher above (it is handled centrally in `AbstractConditionMatcher`, not just by `regular`); `rateLimiter` is the only one without it.
 
 Avoid redefining these type names — SPI registration and Spring registration both key off the `type` string, and a duplicate overrides the built-in factory.
 

--- a/skills/cosec-custom-matcher/SKILL.md
+++ b/skills/cosec-custom-matcher/SKILL.md
@@ -13,7 +13,7 @@ Policy matching has two sides:
 - **ActionMatcher** — determines if a request's action (path + method) matches a policy pattern
 - **ConditionMatcher** — determines if contextual conditions are met (user attributes, request properties, etc.)
 
-Both extend `RequestMatcher` and are created by corresponding factory classes registered via SPI.
+Both matcher interfaces live in `cosec-api` (`me.ahoo.cosec.api.policy`); the factories live in `cosec-core` (`me.ahoo.cosec.policy.action` / `me.ahoo.cosec.policy.condition`) and are created by factory classes registered via SPI.
 
 ```
 Policy
@@ -55,7 +55,7 @@ class PremiumUserConditionMatcher(
 Key points:
 - `type` — unique string identifier used in policy JSON
 - `configuration` — arbitrary key-value config passed from the policy JSON
-- `match()` — return `true` if the condition is satisfied
+- `match()` — return `true` if the condition is satisfied. Throwing here fails the evaluation, so prefer returning `false` for non-matches and reserve exceptions for genuine misconfiguration (the built-in rate limiter, for example, throws to signal TOO_MANY_REQUESTS)
 
 ### Step 2: Implement the Factory
 
@@ -111,7 +111,7 @@ With configuration:
 
 Access configuration in the matcher:
 ```kotlin
-val minTier = configuration.getRequiredString("minTier")
+val minTier = configuration.getRequired("minTier").asString()
 ```
 
 ## Creating a Custom ActionMatcher
@@ -132,7 +132,8 @@ class HttpMethodActionMatcher(
 
     override val type: String = "httpMethod"
 
-    private val allowedMethods: Set<String> = configuration.getRequiredString("methods")
+    private val allowedMethods: Set<String> = configuration.getRequired("methods")
+        .asString()
         .split(",")
         .map { it.trim().uppercase() }
         .toSet()
@@ -185,17 +186,25 @@ com.example.cosec.action.HttpMethodActionMatcherFactory
 
 ## Accessing Configuration Values
 
-The `Configuration` interface provides typed accessors:
+The `Configuration` interface is a tree of typed nodes — there are no convenience accessors like `getRequiredString`; chain a `get`/`getRequired` with an `as*` conversion:
 
 ```kotlin
-// Required (throws if missing)
-val value: String = configuration.getRequiredString("key")
+// Required (getRequired throws IllegalArgumentException if missing)
+val value: String = configuration.getRequired("key").asString()
+val count: Int = configuration.getRequired("key").asInt()
 
 // Optional with default
-val value: String = configuration.get("key", "default")
+val value: String = configuration.get("key")?.asString() ?: "default"
 
-// Nested configuration
-val nested: Configuration = configuration.getRequiredConfiguration("nested")
+// Nested configuration (getRequired returns a Configuration directly)
+val nested: Configuration = configuration.getRequired("nested")
+
+// Collections
+val list: List<String> = configuration.getRequired("tags").asStringList()
+val map: Map<String, String> = configuration.getRequired("labels").asStringMap()
+
+// Existence check
+if (configuration.has("key")) { ... }
 ```
 
 ## Accessing Request and Context Data
@@ -205,8 +214,8 @@ val nested: Configuration = configuration.getRequiredConfiguration("nested")
 request.path           // URL path
 request.method         // HTTP method
 request.remoteIp       // client IP
-request.origin         // Origin header
-request.referer        // Referer header
+request.origin         // Origin as URI; request.origin.host for the host part
+request.referer        // Referer as URI; request.referer.host for the host part
 request.appId          // application ID
 request.spaceId        // space ID
 request.deviceId       // device ID
@@ -222,11 +231,11 @@ securityContext.principal                    // CoSecPrincipal
 securityContext.principal.id                 // user ID
 securityContext.principal.authenticated      // boolean
 securityContext.principal.anonymous          // boolean
-securityContext.principal.roles              // Set<String>
-securityContext.principal.policies           // Set<String>
-securityContext.principal.attributes         // Map<String, String>
-securityContext.tenant                       // Tenant info
-securityContext.attributes                   // MutableMap<String, Any>
+securityContext.principal.roles              // Set<RoleId> (RoleCapable, RoleId = String)
+securityContext.principal.policies           // Set<String> of attached policy IDs (PolicyCapable)
+securityContext.principal.attributes         // Map<String, Any>
+securityContext.tenant                       // Tenant (use .tenantId)
+securityContext.attributes                   // MutableMap<String, Any> (carries path variables etc.)
 ```
 
 ## Built-in ConditionMatcher Types Reference
@@ -249,7 +258,9 @@ For reference, here are all built-in types:
 | `spel` | Spring Expression | `expression` |
 | `ognl` | OGNL expression | `expression` |
 | `rateLimiter` | Rate limiting | `permitsPerSecond` |
-| `groupedRateLimiter` | Grouped rate limit | `permitsPerSecond`, `groupKey` |
+| `groupedRateLimiter` | Grouped rate limit | `part`, `permitsPerSecond`, `expireAfterAccessSecond` |
+
+Avoid redefining these type names — SPI registration and Spring registration both key off the `type` string, and a duplicate overrides the built-in factory.
 
 ## Built-in ActionMatcher Types Reference
 
@@ -261,7 +272,7 @@ For reference, here are all built-in types:
 
 ## Spring Registration (Alternative to SPI)
 
-You can also register matcher factories as Spring beans. The `MatcherFactoryRegister` auto-configuration picks them up from the `ApplicationContext`:
+You can also register matcher factories as Spring beans. The `MatcherFactoryRegister` lifecycle bean picks up every `ConditionMatcherFactory` / `ActionMatcherFactory` bean from the `ApplicationContext` at startup:
 
 ```kotlin
 @Configuration

--- a/skills/cosec-integration/SKILL.md
+++ b/skills/cosec-integration/SKILL.md
@@ -16,7 +16,7 @@ CoSec modules are published to Maven Central under the `me.ahoo.cosec` group. Us
 ```kotlin
 // gradle/libs.versions.toml
 [versions]
-cosec = "4.3.6"  // check latest at https://central.sonatype.com/artifact/me.ahoo.cosec/cosec-bom
+cosec = "4.9.0"  // check latest at https://central.sonatype.com/artifact/me.ahoo.cosec/cosec-bom
 
 [libraries]
 cosec-bom = { module = "me.ahoo.cosec:cosec-bom", version.ref = "cosec" }
@@ -53,7 +53,7 @@ dependencies {
         <dependency>
             <groupId>me.ahoo.cosec</groupId>
             <artifactId>cosec-bom</artifactId>
-            <version>4.3.6</version>
+            <version>4.9.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -96,7 +96,7 @@ dependencies {
 cosec:
   enabled: true                        # master switch (default: true)
   authentication:
-    enabled: true                      # enable authentication
+    enabled: true                      # enable authentication (default: true)
   authorization:
     enabled: true                      # enable authorization (default: true)
     local-policy:
@@ -104,7 +104,7 @@ cosec:
       locations: classpath:cosec-policy/*-policy.json
       init-repository: true            # push local policies to repository on startup
   jwt:
-    algorithm: hmac256                 # hmac256, hmac384, hmac512, rsa256, etc.
+    algorithm: hmac256                 # hmac256 (default), hmac384, hmac512
     secret: your-256-bit-secret-key    # required for HMAC algorithms
 ```
 
@@ -113,15 +113,21 @@ cosec:
 | Property | Default | Description |
 |----------|---------|-------------|
 | `cosec.enabled` | `true` | Master enable/disable switch |
-| `cosec.authentication.enabled` | — | Enable/disable authentication |
+| `cosec.authentication.enabled` | `true` | Enable/disable authentication |
 | `cosec.authorization.enabled` | `true` | Enable/disable authorization |
 | `cosec.authorization.local-policy.enabled` | `false` | Load policies from local JSON files |
 | `cosec.authorization.local-policy.locations` | `classpath:cosec-policy/*-policy.json` | Resource patterns for policy files |
 | `cosec.authorization.local-policy.init-repository` | `false` | Push local policies to repository on startup |
-| `cosec.jwt.algorithm` | — | JWT algorithm (hmac256, rsa256, etc.) |
-| `cosec.jwt.secret` | — | JWT secret key (for HMAC algorithms) |
-| `cosec.ip2region.enabled` | `false` | Enable IP geolocation |
-| `cosec.openapi.enabled` | `false` | Enable OpenAPI integration |
+| `cosec.authorization.local-policy.force-refresh` | `false` | Force-refresh repository policies on init |
+| `cosec.authorization.remote-ip.max-trusted-index` | `1` | Trusted proxy hops for X-Forwarded-For resolution; `0` ignores the header |
+| `cosec.jwt.enabled` | `true` | Enable JWT auto-configuration |
+| `cosec.jwt.algorithm` | `hmac256` | JWT algorithm (`hmac256`, `hmac384`, `hmac512` — RSA is not supported) |
+| `cosec.jwt.secret` | — | JWT secret key (required for HMAC algorithms) |
+| `cosec.jwt.token-validity.access` | `10m` | Access token time-to-live |
+| `cosec.jwt.token-validity.refresh` | `7d` | Refresh token time-to-live |
+| `cosec.jwt.token-revocation.enabled` | `false` | Reject revoked tokens (logout support; back the revocation store with `cosec-cocache` for distributed setups) |
+| `cosec.ip2region.enabled` | `true` | Enable IP geolocation (takes effect when `cosec-ip2region` is on the classpath) |
+| `cosec.openapi.enabled` | `true` | Enable OpenAPI integration (takes effect when `cosec-openapi` is on the classpath) |
 
 ## Step 3: Create Policy Files
 
@@ -196,6 +202,7 @@ The auto-configuration automatically registers:
 - `SimpleAuthorization` for policy evaluation
 - `LocalPolicyLoader` / `LocalPolicyInitializer` for loading local policy files
 - JWT token converter and verifier (if `cosec-jwt` is on classpath)
+- `TokenStore` / `TokenRevoker` / `RevocableTokenVerifier` for token revocation (if `cosec.jwt.token-revocation.enabled=true`)
 - Request parsers for both reactive and servlet environments
 
 ## Gateway Server Reference
@@ -235,7 +242,7 @@ cosec:
   authorization:
     enabled: false            # disable only authorization
   jwt:
-    # not configuring jwt disables JWT auto-config
+    enabled: false            # disable JWT auto-config
   ip2region:
     enabled: false
 ```
@@ -247,4 +254,6 @@ Each auto-configuration class has a corresponding `@ConditionalOn*Enabled` annot
 - **403 on all requests**: Check that policy files exist and match the `locations` pattern. Enable debug logging: `logging.level.me.ahoo.cosec.authorization.SimpleAuthorization=debug`
 - **JWT token not recognized**: Verify `cosec.jwt.secret` and `cosec.jwt.algorithm` match what the token issuer uses
 - **Policies not loading**: Ensure `cosec.authorization.local-policy.enabled=true` and files are in the correct classpath location
-- **Root user bypasses everything**: This is by design. Root user ID defaults to `"cosec"` (configurable via `cosec.root` system property)
+- **Root user bypasses everything**: This is by design. Root user ID defaults to `"cosec"` (override with the `cosec.root` system property)
+
+For deeper debugging workflows, see the `cosec-troubleshoot` skill.

--- a/skills/cosec-integration/SKILL.md
+++ b/skills/cosec-integration/SKILL.md
@@ -202,7 +202,7 @@ The auto-configuration automatically registers:
 - `SimpleAuthorization` for policy evaluation
 - `LocalPolicyLoader` / `LocalPolicyInitializer` for loading local policy files
 - JWT token converter and verifier (if `cosec-jwt` is on classpath)
-- `TokenStore` / `TokenRevoker` / `RevocableTokenVerifier` for token revocation (if `cosec.jwt.token-revocation.enabled=true`)
+- Token revocation beans (`TokenStore` / `TokenRevoker` / `RevocableTokenVerifier`) — revocation takes effect only with `cosec.jwt.token-revocation.enabled=true` plus a Redis-backed store (`cosec-cocache`)
 - Request parsers for both reactive and servlet environments
 
 ## Gateway Server Reference

--- a/skills/cosec-policy-author/SKILL.md
+++ b/skills/cosec-policy-author/SKILL.md
@@ -148,7 +148,7 @@ Matches all GET requests regardless of path.
 
 ## Condition Matchers
 
-The `condition` field adds additional constraints beyond path matching. All condition types:
+The `condition` field adds additional constraints beyond path matching. An omitted condition defaults to match-all (`all`). All condition types:
 
 ### authenticated — user must be logged in
 ```json
@@ -160,10 +160,11 @@ The `condition` field adds additional constraints beyond path matching. All cond
 "condition": { "inRole": { "value": "admin" } }
 ```
 
-### inTenant — request must be from the specified tenant
+### inTenant — request must be from the specified tenant type
 ```json
-"condition": { "inTenant": { "value": "tenant-abc" } }
+"condition": { "inTenant": { "value": "platform" } }
 ```
+`value` is a tenant **type** — `default`, `user`, or `platform` — not a tenant ID. Any other string makes the policy fail to load: the error is logged and the policy is **silently skipped** at startup, so its rules stop applying (watch for 403s).
 
 ### eq — exact value match
 ```json
@@ -281,7 +282,7 @@ All items in `and` must match. At least one item in `or` must match. Both are op
   }
 }
 ```
-When the limit is exceeded the request fails with TOO_MANY_REQUESTS (HTTP 429) rather than a normal deny. Rate limiter state is in-memory; use `cosec-cocache` (Redis) for a shared limit across instances.
+When the limit is exceeded the request fails with TOO_MANY_REQUESTS (HTTP 429) rather than a normal deny. `rateLimiter` creates a single limiter shared by all matching requests; `groupedRateLimiter` creates one per group value. Both are in-memory and per-JVM-instance — `cosec-cocache` provides **no** rate limiting (it only caches policies/permissions/tokens), so a limit shared across instances requires a custom ConditionMatcher backed by Redis or another shared store.
 
 ### groupedRateLimiter — per-group rate limiting
 ```json
@@ -420,7 +421,7 @@ When reviewing a policy, check:
 2. **SpEL templates** — `#{principal.id}` is valid; `{principal.id}` is NOT (it is parsed as a path variable or literal)
 3. **Path variables** — use `{varName}` syntax, access via `request.path.var.varName` in conditions
 4. **Wildcard with conditions** — `"action": "*"` alone allows everything; always pair with a condition
-5. **Negate logic** — `regular` matcher has `negate` field; other matchers don't
+5. **Negate logic** — every condition matcher accepts `negate: true` (handled centrally in `AbstractConditionMatcher`); `rateLimiter` is the only exception
 6. **Bool structure** — `and` and `or` are sibling fields, not nested
 7. **Part paths** — must be valid (singular `request.header.{name}`, not `request.headers.{name}`); invalid parts throw `IllegalArgumentException` at evaluation time
 8. **Policy type** — `global` policies apply to all requests; `custom` policies are attached to specific users/roles

--- a/skills/cosec-policy-author/SKILL.md
+++ b/skills/cosec-policy-author/SKILL.md
@@ -34,7 +34,7 @@ A policy file is a single JSON object placed in `src/main/resources/cosec-policy
 | `description` | No | Detailed description |
 | `type` | Yes | `global` (applies to all requests), `system` (system-level), or `custom` (user/role-specific) |
 | `tenantId` | Yes | Tenant scope. Use `(platform)` for global/system policies |
-| `condition` | No | Policy-level ConditionMatcher — if present and doesn't match, entire policy is skipped |
+| `condition` | No | Policy-level ConditionMatcher — if present and doesn't match, this policy is **skipped** (other policies still evaluate) |
 | `statements` | Yes | Array of Statement objects |
 
 ## Statement Structure
@@ -52,19 +52,21 @@ Each statement defines a single permission rule:
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `name` | No | — | Descriptive name for the statement |
+| `name` | No | `""` | Descriptive name for the statement |
 | `effect` | No | `"allow"` | `"allow"` or `"deny"`. DENY takes precedence over ALLOW |
 | `action` | Yes | — | ActionMatcher definition (see below) |
-| `condition` | No | — | ConditionMatcher definition (see below) |
+| `condition` | No | match-all | ConditionMatcher definition (see below) |
 
 ## Evaluation Order
 
-1. Policy-level condition checked first — if it doesn't match, the entire policy returns IMPLICIT_DENY
-2. **DENY statements evaluated first** — any match returns EXPLICIT_DENY immediately
-3. **ALLOW statements evaluated next** — any match returns ALLOW
-4. Default: IMPLICIT_DENY
+Within one evaluation tier (global policies, or principal-attached policies), CoSec pools **all statements from all policies whose policy-level condition matched**, then evaluates them deny-first:
 
-This means you should write DENY rules before ALLOW rules in the statements array for clarity, though the framework handles ordering internally.
+1. Policies whose policy-level `condition` doesn't match are skipped entirely — this does NOT deny the request
+2. **All DENY statements are checked first** — any match returns EXPLICIT_DENY immediately, even if an ALLOW statement in another policy would also match
+3. **ALLOW statements are checked next** — any match returns ALLOW
+4. If nothing matched in this tier, the next tier is tried; if no tier matches, the default is IMPLICIT_DENY
+
+A practical consequence: a DENY statement in ANY policy of the same tier overrides an ALLOW in ANY other policy. Write DENY statements before ALLOW rules in the statements array for readability, though the framework pools statements before evaluating.
 
 ## Action Matchers
 
@@ -92,7 +94,7 @@ Matches path segments. Access the variable in conditions via `request.path.var.i
 ```json
 "action": ["/auth/register", "/auth/login", "/auth/logout"]
 ```
-Matches if ANY path in the array matches.
+Matches if ANY path in the array matches. An array containing `"*"` matches all requests.
 
 ### Wildcard
 ```json
@@ -174,11 +176,16 @@ The `condition` field adds additional constraints beyond path matching. All cond
 ```
 
 The `part` field is a path expression that extracts a value from the request or security context:
+- `request.path` — full request path
 - `request.path.var.{name}` — path variable
-- `request.remoteIp` — client IP
-- `request.origin` — request origin
 - `request.method` — HTTP method
+- `request.remoteIp` — client IP
+- `request.origin` — request origin; `request.origin.host` — origin host
+- `request.referer` — referer; `request.referer.host` — referer host
+- `request.appId` / `request.spaceId` / `request.deviceId` — request identifiers
+- `request.header.{name}` — request header (singular `header`)
 - `request.attributes.{key}` — request attributes (e.g., `request.attributes.ipRegion`)
+- `context.tenantId` — current tenant ID
 - `context.principal.id` — current user ID
 - `context.principal.attributes.{key}` — principal attributes
 
@@ -274,16 +281,19 @@ All items in `and` must match. At least one item in `or` must match. Both are op
   }
 }
 ```
+When the limit is exceeded the request fails with TOO_MANY_REQUESTS (HTTP 429) rather than a normal deny. Rate limiter state is in-memory; use `cosec-cocache` (Redis) for a shared limit across instances.
 
-### groupedRateLimiter — grouped rate limiting
+### groupedRateLimiter — per-group rate limiting
 ```json
 "condition": {
   "groupedRateLimiter": {
+    "part": "context.principal.id",
     "permitsPerSecond": 100,
-    "groupKey": "context.principal.id"
+    "expireAfterAccessSecond": 60
   }
 }
 ```
+The group is selected by `part` (any valid part path, e.g. `context.principal.id` for per-user limits). Both `permitsPerSecond` and `expireAfterAccessSecond` (idle expiry of each group's limiter) are required. Exceeding the limit yields TOO_MANY_REQUESTS.
 
 ## Common Patterns
 
@@ -406,11 +416,12 @@ All items in `and` must match. At least one item in `or` must match. Both are op
 
 When reviewing a policy, check:
 
-1. **DENY before ALLOW** — while the framework handles ordering, writing DENY statements first improves readability
-2. **SpEL templates** — `#{principal.id}` is valid; `{principal.id}` is NOT (conflicts with path variables)
+1. **DENY before ALLOW** — DENY in any same-tier policy overrides ALLOW elsewhere; writing DENY statements first improves readability
+2. **SpEL templates** — `#{principal.id}` is valid; `{principal.id}` is NOT (it is parsed as a path variable or literal)
 3. **Path variables** — use `{varName}` syntax, access via `request.path.var.varName` in conditions
 4. **Wildcard with conditions** — `"action": "*"` alone allows everything; always pair with a condition
 5. **Negate logic** — `regular` matcher has `negate` field; other matchers don't
 6. **Bool structure** — `and` and `or` are sibling fields, not nested
-7. **Part paths** — must be valid: `request.*`, `context.principal.*`, `request.path.var.*`, `request.attributes.*`
+7. **Part paths** — must be valid (singular `request.header.{name}`, not `request.headers.{name}`); invalid parts throw `IllegalArgumentException` at evaluation time
 8. **Policy type** — `global` policies apply to all requests; `custom` policies are attached to specific users/roles
+9. **groupedRateLimiter** — requires `part`, `permitsPerSecond`, and `expireAfterAccessSecond`; there is no `groupKey` field

--- a/skills/cosec-troubleshoot/SKILL.md
+++ b/skills/cosec-troubleshoot/SKILL.md
@@ -5,7 +5,7 @@ description: "Use when diagnosing CoSec authentication or authorization failures
 
 # CoSec Troubleshooting Guide
 
-This skill helps you debug authorization issues in CoSec. When a request gets an unexpected result (403, 401, or is allowed when it shouldn't be), follow this systematic approach.
+This skill helps you debug authorization issues in CoSec. When a request gets an unexpected result (403, 401, 429, or is allowed when it shouldn't be), follow this systematic approach.
 
 ## Step 1: Enable Debug Logging
 
@@ -17,7 +17,7 @@ logging:
     me.ahoo.cosec.authorization.SimpleAuthorization: debug
 ```
 
-This logs the full evaluation chain: root check → blacklist → global policies → principal policies → role permissions → final result.
+This logs every matched statement, the policy/statement it came from, and the final result, e.g. `Verify [request] [context] matched Policy[globalPolicy] Statement[2][RequestOriginDeny] - [Explicit Deny].`
 
 For more granular tracing:
 ```yaml
@@ -30,34 +30,33 @@ logging:
 
 ## Step 2: Understand the Evaluation Order
 
-`SimpleAuthorization` evaluates in this order, stopping at the first definitive result:
+`SimpleAuthorization.authorize` evaluates in this order, falling through with `switchIfEmpty` when a step produces no match:
 
 ```
 1. Root user check
-   └─ If principal.id == "cosec" → ALLOW (bypass everything)
+   └─ If principal.id == root ID (default "cosec") → ALLOW (bypass everything)
 
 2. Blacklist check
    └─ If principal is blacklisted → EXPLICIT_DENY
 
 3. Global policies (type: "global")
-   └─ For each global policy:
-      a. Check policy-level condition → skip if no match
-      b. Check DENY statements → EXPLICIT_DENY if any matches
-      c. Check ALLOW statements → ALLOW if any matches
-   └─ First definitive result wins
+   └─ Skip policies whose policy-level condition doesn't match
+   └─ Pool ALL statements from ALL matched policies, then deny-first:
+      a. Check every DENY statement → EXPLICIT_DENY if any matches
+      b. Check every ALLOW statement → ALLOW if any matches
 
 4. Principal-specific policies
    └─ Policies attached to the user (via policy IDs on the principal)
-   └─ Same evaluation as global policies
+   └─ Same pooled deny-first evaluation as global policies
 
 5. Role-based app permissions
-   └─ Evaluate role permissions for the request's appId/spaceId
-   └─ Only applies when request has an appId
+   └─ Only when the principal has roles; permissions are looked up
+      by request.appId + request.spaceId, then evaluated deny-first
 
 6. Default → IMPLICIT_DENY
 ```
 
-Each step uses `switchIfEmpty` to fall through to the next if no match is found.
+Key consequence: a DENY statement in ANY policy of the same tier beats an ALLOW statement in ANY other policy of that tier — policy order within a tier does not matter.
 
 ## Step 3: Common Issues and Fixes
 
@@ -99,8 +98,8 @@ cosec:
 
 **Likely causes:**
 1. DENY statement doesn't match — check action pattern and condition
-2. Another ALLOW statement matches first (but DENY should take precedence)
-3. Root user bypass — check if the user ID is "cosec"
+2. An ALLOW statement in a LATER tier matches (tiers fall through: global → principal → role permissions) — a DENY only overrides ALLOW within the same tier
+3. Root user bypass — check if the user ID equals the root ID (default `"cosec"`, override with the `cosec.root` system property)
 
 **Debug:** Enable debug logging and check which statement matched.
 
@@ -110,9 +109,9 @@ cosec:
 
 **Likely causes:**
 1. `cosec.jwt.secret` doesn't match the token issuer's secret
-2. `cosec.jwt.algorithm` doesn't match the token's algorithm
-3. Token is expired
-4. Token format is wrong (not a standard JWT)
+2. `cosec.jwt.algorithm` doesn't match the token's algorithm (supported: `hmac256`, `hmac384`, `hmac512`)
+3. Token is expired (`token-validity.access` defaults to 10 minutes)
+4. Token was revoked (logout) while `cosec.jwt.token-revocation.enabled=true`
 
 **Check:**
 ```yaml
@@ -120,6 +119,11 @@ cosec:
   jwt:
     algorithm: hmac256    # must match the signing algorithm
     secret: exact-same-secret-used-by-issuer
+    token-validity:
+      access: 10m         # access token TTL
+      refresh: 7d         # refresh token TTL
+    token-revocation:
+      enabled: false      # when true, revoked (logged-out) tokens are rejected
 ```
 
 ### Policies not loading from local files
@@ -135,11 +139,11 @@ cosec:
 
 ### Rate limiter not working
 
-**Symptoms:** Rate limiting conditions are ignored.
+**Symptoms:** Rate limiting conditions are ignored, or limits are per-instance instead of global.
 
-**Cause:** Rate limiters require a shared state. In a distributed setup, you need Redis-backed caching (`cosec-cocache`).
+**Cause:** Rate limiters keep state in memory. In a distributed setup, you need Redis-backed state (`cosec-cocache`).
 
-**Fix:** Add the cocache dependency and configure Redis.
+**Fix:** Add the cocache dependency and configure Redis. Also note: a tripped limiter produces `TOO_MANY_REQUESTS` (HTTP 429), not a plain 403.
 
 ### Path variables not matching
 
@@ -160,70 +164,99 @@ cosec:
 
 ### Condition part path is wrong
 
-**Symptoms:** Condition always returns false.
+**Symptoms:** Condition always returns false, or evaluation throws `IllegalArgumentException: Unsupported part`.
 
 **Valid part paths:**
+- `request.path` — full request path
 - `request.path.var.{name}` — path variable
-- `request.remoteIp` — client IP address
-- `request.origin` — Origin header
 - `request.method` — HTTP method
+- `request.remoteIp` — client IP address
+- `request.origin` — Origin; `request.origin.host` — origin host
+- `request.referer` — Referer; `request.referer.host` — referer host
+- `request.appId` / `request.spaceId` / `request.deviceId` — identifiers
+- `request.header.{name}` — request header (singular `header`)
 - `request.attributes.{key}` — request attributes
-- `request.headers.{name}` — request header
+- `context.tenantId` — tenant ID
 - `context.principal.id` — user ID
 - `context.principal.attributes.{key}` — principal attribute
 
 Common mistakes:
+- `request.headers.X-Foo` (wrong) → `request.header.X-Foo` (correct)
 - `request.ip` (wrong) → `request.remoteIp` (correct)
 - `principal.id` (wrong) → `context.principal.id` (correct)
 - `request.pathVariable.id` (wrong) → `request.path.var.id` (correct)
 
 ## Step 4: Testing Policies Locally
 
-### Unit test with SimpleAuthorization
+These patterns mirror the real tests in `cosec-core/src/test/kotlin/me/ahoo/cosec/authorization/SimpleAuthorizationTest.kt`.
+
+### Unit test a full authorization decision
 
 ```kotlin
 @Test
 fun `test policy evaluation`() {
-    val policyLoader = LocalPolicyLoader("classpath:cosec-policy/test-policy.json")
-    val policies = policyLoader.load()
+    val globalPolicy = mockk<Policy> {
+        every { id } returns "globalPolicy"
+        every { condition } returns AllConditionMatcher.INSTANCE
+        every { statements } returns listOf(
+            StatementData(
+                name = "PublicEndpoints",
+                effect = Effect.ALLOW,
+                action = PathActionMatcherFactory.INSTANCE
+                    .create(mapOf("pattern" to "/api/users/*").asConfiguration()),
+            ),
+        )
+    }
+    val policyRepository = mockk<PolicyRepository> {
+        every { getGlobalPolicy() } returns Mono.just(listOf(globalPolicy))
+        every { getPolicies(any()) } returns Mono.empty()
+    }
+    val permissionRepository = mockk<AppRolePermissionRepository> {
+        every { getAppRolePermission(any(), any(), any()) } returns Mono.empty()
+    }
 
-    val evaluator = DefaultPolicyEvaluator(policies)
-
+    val authorization = SimpleAuthorization(policyRepository, permissionRepository)
     val request = mockk<Request> {
         every { path } returns "/api/users/123"
         every { method } returns "GET"
-        every { remoteIp } returns "192.168.1.1"
+    }
+    // relaxed: evaluation writes path variables and the verify context into the context
+    val securityContext = mockk<SecurityContext>(relaxed = true) {
+        every { principal.id } returns "user-123"
     }
 
-    val principal = mockk<CoSecPrincipal> {
-        every { id } returns "user-123"
-        every { authenticated } returns true
-        every { roles } returns setOf("user")
-    }
-
-    val context = mockk<SecurityContext> {
-        every { this@mockk.principal } returns principal
-    }
-
-    val result = evaluator.evaluate(request, context)
-    assertThat(result.authorized).isTrue()
+    authorization.authorize(request, securityContext)
+        .test()
+        .expectNext(AuthorizeResult.ALLOW)
+        .verifyComplete()
 }
 ```
 
-### Test specific matcher
+Imports worth knowing: `me.ahoo.cosec.configuration.JsonConfiguration.Companion.asConfiguration` for building matchers from maps, `me.ahoo.cosec.policy.StatementData` / `me.ahoo.cosec.policy.action.PathActionMatcherFactory` for real (non-mock) matchers, and `reactor.kotlin.test.test` for stepping through the `Mono`.
+
+### Smoke-test a local policy file
+
+`LocalPolicyLoader` takes a set of resource patterns and exposes loaded policies as a property; `DefaultPolicyEvaluator` is a stateless object that dry-runs every matcher of a policy against a mock request to surface configuration errors (it swallows rate-limit and regex-timeout errors):
+
+```kotlin
+val policies = LocalPolicyLoader(setOf("classpath:cosec-policy/test-policy.json")).policies
+policies.forEach { DefaultPolicyEvaluator.evaluate(it) }
+```
+
+### Test a specific matcher
 
 ```kotlin
 @Test
 fun `test path action matcher`() {
-    val factory = PathActionMatcherFactory()
-    val matcher = factory.create(Configuration.of("pattern" to "/api/users/*"))
+    val matcher = PathActionMatcherFactory.INSTANCE
+        .create(mapOf("pattern" to "/api/users/*").asConfiguration())
 
     val request = mockk<Request> {
         every { path } returns "/api/users/123"
         every { method } returns "GET"
     }
 
-    assertThat(matcher.match(request, mockk())).isTrue()
+    matcher.match(request, SimpleSecurityContext.anonymous()).assert().isTrue()
 }
 ```
 
@@ -253,7 +286,7 @@ fun whoami(exchange: ServerWebExchange): Mono<Map<String, Any?>> {
 | Result | `authorized` | Meaning |
 |--------|-------------|---------|
 | `ALLOW` | `true` | Explicitly allowed by a policy statement |
-| `EXPLICIT_DENY` | `false` | Explicitly denied by a DENY statement |
+| `EXPLICIT_DENY` | `false` | Explicitly denied by a DENY statement or blacklist |
 | `IMPLICIT_DENY` | `false` | No statement matched (default deny) |
 | `TOKEN_EXPIRED` | `false` | JWT token has expired |
 | `TOO_MANY_REQUESTS` | `false` | Rate limiter exceeded |

--- a/skills/cosec-troubleshoot/SKILL.md
+++ b/skills/cosec-troubleshoot/SKILL.md
@@ -17,7 +17,7 @@ logging:
     me.ahoo.cosec.authorization.SimpleAuthorization: debug
 ```
 
-This logs every matched statement, the policy/statement it came from, and the final result, e.g. `Verify [request] [context] matched Policy[globalPolicy] Statement[2][RequestOriginDeny] - [Explicit Deny].`
+This logs every matched statement, the policy/statement it came from, and the final result, e.g. `Verify [request] [context] matched Policy[globalPolicy] Statement[2][RequestOriginDeny] - [EXPLICIT_DENY].` (statement index is 0-based)
 
 For more granular tracing:
 ```yaml
@@ -139,18 +139,18 @@ cosec:
 
 ### Rate limiter not working
 
-**Symptoms:** Rate limiting conditions are ignored, or limits are per-instance instead of global.
+**Symptoms:** Limits are per-instance instead of shared across the cluster.
 
-**Cause:** Rate limiters keep state in memory. In a distributed setup, you need Redis-backed state (`cosec-cocache`).
+**Cause:** Both `rateLimiter` and `groupedRateLimiter` keep state in memory, per JVM instance — there is no built-in distributed limiter, and `cosec-cocache` does not provide one (it only caches policies/permissions/tokens).
 
-**Fix:** Add the cocache dependency and configure Redis. Also note: a tripped limiter produces `TOO_MANY_REQUESTS` (HTTP 429), not a plain 403.
+**Fix:** Implement a custom `ConditionMatcher` backed by a shared store such as Redis — see the `cosec-custom-matcher` skill. Also note: a tripped limiter produces `TOO_MANY_REQUESTS` (HTTP 429), not a plain 403.
 
 ### Path variables not matching
 
 **Symptoms:** `/user/123` doesn't match `/user/{id}`.
 
 **Check:**
-1. Use `{varName}` not `:varName` (Spring WebFlux style)
+1. Use `{varName}` — the `:varName` colon syntax is not supported by CoSec's path patterns
 2. Access the variable via `request.path.var.varName` in conditions
 3. Ensure the path pattern is correct (no trailing slash mismatch)
 


### PR DESCRIPTION
## Summary

Full accuracy audit of the four AI-assistant skills under `skills/` (`cosec-policy-author`, `cosec-troubleshoot`, `cosec-integration`, `cosec-custom-matcher`). Every API, config key, class name, default value, and behavior claim was verified against the source code in this repository, then the code examples were validated by running them as real JUnit tests in `cosec-core`.

## Changes

**Factual fixes (commit ff4997dc):**
- Version reference `4.3.6` → `4.9.0`; JWT algorithm is HMAC-only (`hmac256`/`hmac384`/`hmac512`) — `rsa256` is not supported by `JwtProperties.Algorithm`
- Condition part path corrected to singular `request.header.{name}`; documented 8 previously missing part paths (`request.path`, `request.appId`, `request.spaceId`, `request.deviceId`, `request.referer`, `request.origin.host`, `request.referer.host`, `context.tenantId`)
- `groupedRateLimiter` keys corrected to `part` + `permitsPerSecond` + required `expireAfterAccessSecond` (`groupKey` does not exist)
- Replaced fabricated unit-test examples (nonexistent `DefaultPolicyEvaluator(policies)` constructor, wrong `PolicyEvaluator.evaluate` signature, nonexistent `LocalPolicyLoader.load()` / `Configuration.of(...)`) with the real patterns from `SimpleAuthorizationTest.kt`
- `Configuration` accessors corrected: `getRequired(key).asString()` etc. (`getRequiredString` / `get(key, default)` / `getRequiredConfiguration` do not exist); `principal.attributes` is `Map<String, Any>`
- Property defaults corrected (`authentication`/`ip2region`/`openapi` enabled default `true`); added `token-validity`, `token-revocation`, `force-refresh`, `remote-ip.max-trusted-index`
- Evaluation semantics corrected: a non-matching policy-level condition skips the policy (not IMPLICIT_DENY); deny-first evaluation pools all statements across policies within a tier

**Code-review fixes (commit 017eeb6f):**
- `inTenant` value is a tenant **type** (`default`/`user`/`platform`), not a tenant ID; an invalid value makes `LocalPolicyLoader` silently skip the policy
- Removed the impossible advice to use `cosec-cocache` for distributed rate limiting — the module provides no rate limiting; built-in limiters are in-memory per JVM instance
- `negate` is accepted by every condition matcher (handled in `AbstractConditionMatcher`), not just `regular`; `rateLimiter` is the only exception
- Debug-log sample corrected to the actual `VerifyResult` enum output (`[EXPLICIT_DENY]`); added the missing `all` condition type; minor wording fixes

## Testing

- [x] All replaced code examples were run as temporary JUnit tests in `cosec-core` (mockk + reactor-test patterns mirroring `SimpleAuthorizationTest.kt`) — 5/5 passed, then removed
- [x] End-to-end: a policy authored per the skill (admin + per-user grouped rate limit) loads and evaluates correctly (ALLOW / IMPLICIT_DENY / `TooManyRequestsException` on limit trip / group isolation)
- [x] End-to-end: custom `premiumUser` ConditionMatcher registered via `ConditionMatcherFactoryProvider` works through JSON deserialization and evaluation
- [x] Review fixes verified: invalid `inTenant` value → policy skipped by loader; valid tenant type → loads; `negate` inverts `eq` (3/3 passed)
- [x] No changes to production code — documentation only
