### PR TITLE
feat: add Redis distributed rate limiting (redisRateLimiter/redisGroupedRateLimiter)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docs/superpowers/
 
 # Local Redis dump from cocache integration tests
 dump.rdb
+.zcode/

--- a/cosec-cocache/build.gradle.kts
+++ b/cosec-cocache/build.gradle.kts
@@ -14,6 +14,7 @@
 dependencies {
     api(project(":cosec-core"))
     api("me.ahoo.cocache:cocache-core")
+    api("org.springframework.data:spring-data-redis")
     testImplementation("me.ahoo.cocache:cocache-spring-redis")
     testImplementation("io.lettuce:lettuce-core")
     testImplementation("me.ahoo.cosid:cosid-core")

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcher.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcher.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.cache.limiter
+
+import me.ahoo.cosec.api.configuration.Configuration
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.policy.ConditionMatcher
+import me.ahoo.cosec.policy.condition.ConditionMatcherFactory
+import me.ahoo.cosec.policy.condition.limiter.RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY
+import me.ahoo.cosec.policy.condition.part.PartConditionMatcher
+import org.springframework.data.redis.core.StringRedisTemplate
+
+/**
+ * Distributed rate limiter condition matcher backed by Redis, grouped by a part
+ * value (e.g. `request.remoteIp`), so each group gets its own quota.
+ */
+class RedisGroupedRateLimiterConditionMatcher(
+    configuration: Configuration,
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val keyPrefix: String = DEFAULT_REDIS_RATE_LIMITER_KEY_PREFIX
+) : PartConditionMatcher(RedisGroupedRateLimiterConditionMatcherFactory.TYPE, configuration) {
+
+    private val permitsPerSecond: Double =
+        requireNotNull(configuration.get(RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY)) {
+            "permitsPerSecond is required!"
+        }.asDouble()
+
+    private val windowSeconds: Long = configuration
+        .get(REDIS_RATE_LIMITER_CONDITION_MATCHER_WINDOW_SECONDS_KEY)?.asLong() ?: 1
+
+    private val strictFailure: Boolean = configuration
+        .get(REDIS_RATE_LIMITER_CONDITION_MATCHER_STRICT_FAILURE_KEY)?.asBoolean() ?: false
+
+    private val rateLimiter = RedisSlidingWindowRateLimiter(
+        stringRedisTemplate = stringRedisTemplate,
+        keyPrefix = keyPrefix,
+        permitsPerSecond = permitsPerSecond,
+        windowSeconds = windowSeconds,
+        strictFailure = strictFailure,
+    )
+
+    override fun matchPart(partValue: String, securityContext: SecurityContext): Boolean {
+        return rateLimiter.tryAcquire(partValue)
+    }
+}
+
+class RedisGroupedRateLimiterConditionMatcherFactory(
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val keyPrefix: String = DEFAULT_REDIS_RATE_LIMITER_KEY_PREFIX
+) : ConditionMatcherFactory {
+    companion object {
+        const val TYPE = "redisGroupedRateLimiter"
+    }
+
+    override val type: String
+        get() = TYPE
+
+    override fun create(configuration: Configuration): ConditionMatcher {
+        return RedisGroupedRateLimiterConditionMatcher(configuration, stringRedisTemplate, keyPrefix)
+    }
+}

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcher.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcher.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.cache.limiter
+
+import me.ahoo.cosec.api.configuration.Configuration
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.api.policy.ConditionMatcher
+import me.ahoo.cosec.policy.condition.ConditionMatcherFactory
+import me.ahoo.cosec.policy.condition.limiter.RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY
+import org.springframework.data.redis.core.StringRedisTemplate
+
+const val REDIS_RATE_LIMITER_CONDITION_MATCHER_WINDOW_SECONDS_KEY = "windowSeconds"
+const val REDIS_RATE_LIMITER_CONDITION_MATCHER_STRICT_FAILURE_KEY = "strictFailure"
+const val DEFAULT_REDIS_RATE_LIMITER_KEY_PREFIX = "cosec:rate-limiter"
+
+/**
+ * Distributed rate limiter condition matcher backed by Redis.
+ *
+ * Applies the sliding-window (interpolated counters) algorithm atomically
+ * via a single Lua script, so the limit is enforced cluster-wide.
+ */
+class RedisRateLimiterConditionMatcher(
+    override val configuration: Configuration,
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val keyPrefix: String = DEFAULT_REDIS_RATE_LIMITER_KEY_PREFIX
+) : ConditionMatcher {
+
+    override val type: String
+        get() = RedisRateLimiterConditionMatcherFactory.TYPE
+
+    private val permitsPerSecond: Double =
+        requireNotNull(configuration.get(RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY)) {
+            "permitsPerSecond is required!"
+        }.asDouble()
+
+    private val windowSeconds: Long = configuration
+        .get(REDIS_RATE_LIMITER_CONDITION_MATCHER_WINDOW_SECONDS_KEY)?.asLong() ?: 1
+
+    private val strictFailure: Boolean = configuration
+        .get(REDIS_RATE_LIMITER_CONDITION_MATCHER_STRICT_FAILURE_KEY)?.asBoolean() ?: false
+
+    private val rateLimiter = RedisSlidingWindowRateLimiter(
+        stringRedisTemplate = stringRedisTemplate,
+        keyPrefix = keyPrefix,
+        permitsPerSecond = permitsPerSecond,
+        windowSeconds = windowSeconds,
+        strictFailure = strictFailure,
+    )
+
+    override fun match(request: Request, securityContext: SecurityContext): Boolean {
+        return rateLimiter.tryAcquire()
+    }
+}
+
+class RedisRateLimiterConditionMatcherFactory(
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val keyPrefix: String = DEFAULT_REDIS_RATE_LIMITER_KEY_PREFIX
+) : ConditionMatcherFactory {
+    companion object {
+        const val TYPE = "redisRateLimiter"
+    }
+
+    override val type: String
+        get() = TYPE
+
+    override fun create(configuration: Configuration): ConditionMatcher {
+        return RedisRateLimiterConditionMatcher(configuration, stringRedisTemplate, keyPrefix)
+    }
+}

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiter.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiter.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.cache.limiter
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import org.springframework.dao.DataAccessException
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import java.security.MessageDigest
+
+/**
+ * Sliding-window (interpolated counters) rate limiter backed by Redis.
+ *
+ * The whole check-and-count happens atomically in a single Lua script, so the
+ * limit is enforced cluster-wide. State is two counters per window (current and
+ * previous, weighted by elapsed time), which bounds memory to O(1) per group and
+ * avoids the boundary burst hole of a plain fixed window.
+ *
+ * Redis keys expire naturally after two windows, so per-group keys never leak.
+ */
+class RedisSlidingWindowRateLimiter(
+    private val stringRedisTemplate: StringRedisTemplate,
+    keyPrefix: String,
+    private val permitsPerSecond: Double,
+    private val windowSeconds: Long,
+    private val strictFailure: Boolean
+) {
+    companion object {
+        private val log = KotlinLogging.logger {}
+
+        /** Script resource next to this class, see `redis-rate-limiter.lua` in the module resources. */
+        private const val SCRIPT_PATH = "redis-rate-limiter.lua"
+
+        private const val GLOBAL_GROUP = "global"
+
+        /** Distinguishes grouped keys from the global key, so a group literally named "global" cannot collide. */
+        private const val GROUP_PREFIX = "g:"
+
+        /** Emit at most one failure log per interval to avoid a log storm during an outage. */
+        private const val FAILURE_LOG_INTERVAL_MS = 10_000L
+
+        private val SCRIPT: DefaultRedisScript<Long> = DefaultRedisScript(
+            loadScript(),
+            Long::class.javaObjectType,
+        )
+
+        private fun loadScript(): String {
+            val script = RedisSlidingWindowRateLimiter::class.java.getResourceAsStream(SCRIPT_PATH)
+                ?: error("Redis rate limiter script [$SCRIPT_PATH] not found on the classpath.")
+            return script.bufferedReader().use { it.readText() }
+        }
+
+        private fun sha1Hex(value: String): String {
+            val digest = MessageDigest.getInstance("SHA-1").digest(value.toByteArray())
+            return digest.joinToString("") { "%02x".format(it) }.take(12)
+        }
+    }
+
+    init {
+        require(permitsPerSecond > 0) { "permitsPerSecond must be positive, but was [$permitsPerSecond]." }
+        require(windowSeconds >= 1) { "windowSeconds must be >= 1, but was [$windowSeconds]." }
+    }
+
+    /**
+     * Config-derived key segment, so policies with different limits never share
+     * counters while policies with identical limits share one cluster-wide quota.
+     */
+    private val configHash: String = sha1Hex("$permitsPerSecond|$windowSeconds|$strictFailure")
+
+    private val keyPrefix: String = keyPrefix.trimEnd(':')
+
+    private val limitPerWindow: Double = permitsPerSecond * windowSeconds
+
+    @Volatile
+    private var lastFailureLogAt = 0L
+
+    fun tryAcquire(): Boolean = tryAcquireInternal(GLOBAL_GROUP, System.currentTimeMillis())
+
+    fun tryAcquire(groupValue: String): Boolean =
+        tryAcquireInternal(GROUP_PREFIX + groupValue, System.currentTimeMillis())
+
+    internal fun tryAcquireInternal(groupKey: String, nowMs: Long): Boolean {
+        val windowMs = windowSeconds * 1_000
+        val windowIndex = nowMs / windowMs
+        val baseKey = "$keyPrefix:$configHash:$groupKey"
+        val result = try {
+            stringRedisTemplate.execute(
+                SCRIPT,
+                listOf("$baseKey:$windowIndex", "$baseKey:${windowIndex - 1}"),
+                limitPerWindow.toString(),
+                windowMs.toString(),
+                nowMs.toString(),
+            )
+        } catch (cause: DataAccessException) {
+            // Any Redis failure (connectivity, script error, timeout) surfaces as a
+            // DataAccessException and takes the configured failure mode.
+            return handleFailure(cause)
+        }
+        if (result == 1L) {
+            return true
+        }
+        throw TooManyRequestsException("Rate limit exceeded - Group[$groupKey]!")
+    }
+
+    private fun handleFailure(cause: DataAccessException): Boolean {
+        val nowMs = System.currentTimeMillis()
+        if (nowMs - lastFailureLogAt >= FAILURE_LOG_INTERVAL_MS) {
+            lastFailureLogAt = nowMs
+            if (strictFailure) {
+                log.error(cause) {
+                    "Redis rate limiter unavailable - failing closed."
+                }
+            } else {
+                log.warn(cause) {
+                    "Redis rate limiter unavailable - failing open."
+                }
+            }
+        }
+        if (strictFailure) {
+            throw TooManyRequestsException("Rate limiter unavailable - denied by strictFailure.")
+        }
+        return true
+    }
+}

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiter.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiter.kt
@@ -61,23 +61,6 @@ class RedisSlidingWindowRateLimiter(
             return script.bufferedReader().use { it.readText() }
         }
 
-        /**
-         * Preloads the Lua script so the very first concurrent burst never races
-         * script loading: on a fresh Redis, concurrent EVALSHA calls can hit
-         * NOSCRIPT while the fallback EVAL is in flight, and a missed fallback
-         * would surface as a failure (fail-open). Warm up at startup (or in
-         * tests) to close that window. Uses a dedicated key, so no quota is touched.
-         */
-        fun warmUp(stringRedisTemplate: StringRedisTemplate) {
-            stringRedisTemplate.execute(
-                SCRIPT,
-                listOf("warmup", "warmup-prev"),
-                "1",
-                "1000",
-                "0",
-            )
-        }
-
         private fun sha1Hex(value: String): String {
             val digest = MessageDigest.getInstance("SHA-1").digest(value.toByteArray())
             return digest.joinToString("") { "%02x".format(it) }.take(12)

--- a/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiter.kt
+++ b/cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiter.kt
@@ -61,6 +61,23 @@ class RedisSlidingWindowRateLimiter(
             return script.bufferedReader().use { it.readText() }
         }
 
+        /**
+         * Preloads the Lua script so the very first concurrent burst never races
+         * script loading: on a fresh Redis, concurrent EVALSHA calls can hit
+         * NOSCRIPT while the fallback EVAL is in flight, and a missed fallback
+         * would surface as a failure (fail-open). Warm up at startup (or in
+         * tests) to close that window. Uses a dedicated key, so no quota is touched.
+         */
+        fun warmUp(stringRedisTemplate: StringRedisTemplate) {
+            stringRedisTemplate.execute(
+                SCRIPT,
+                listOf("warmup", "warmup-prev"),
+                "1",
+                "1000",
+                "0",
+            )
+        }
+
         private fun sha1Hex(value: String): String {
             val digest = MessageDigest.getInstance("SHA-1").digest(value.toByteArray())
             return digest.joinToString("") { "%02x".format(it) }.take(12)

--- a/cosec-cocache/src/main/resources/me/ahoo/cosec/cache/limiter/redis-rate-limiter.lua
+++ b/cosec-cocache/src/main/resources/me/ahoo/cosec/cache/limiter/redis-rate-limiter.lua
@@ -1,0 +1,28 @@
+-- Sliding-window (interpolated counters) rate limiter script.
+--
+-- KEYS[1] - current window counter key
+-- KEYS[2] - previous window counter key
+-- ARGV[1] - quota per window (permitsPerSecond * windowSeconds)
+-- ARGV[2] - window size in milliseconds
+-- ARGV[3] - current epoch millis
+--
+-- Returns 1 when the request is allowed (and counted), 0 when the quota is exceeded.
+-- The check and the count happen atomically, so the limit is enforced cluster-wide.
+--
+-- Note: the two keys are not wrapped in a Redis Cluster hashtag; CoSec has no
+-- cluster support elsewhere, and tagging would pin all counters to one slot.
+
+local current = tonumber(redis.call('GET', KEYS[1]) or '0')
+local previous = tonumber(redis.call('GET', KEYS[2]) or '0')
+local windowMs = tonumber(ARGV[2])
+local nowMs = tonumber(ARGV[3])
+local previousWeight = (windowMs - (nowMs % windowMs)) / windowMs
+local estimate = previous * previousWeight + current
+if estimate >= tonumber(ARGV[1]) then
+  return 0
+end
+redis.call('INCR', KEYS[1])
+if current == 0 then
+  redis.call('PEXPIRE', KEYS[1], windowMs * 2)
+end
+return 1

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcherTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcherTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.cache.limiter
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.configuration.JsonConfiguration.Companion.asConfiguration
+import me.ahoo.cosec.policy.condition.limiter.RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY
+import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import me.ahoo.cosec.policy.condition.part.CONDITION_MATCHER_PART_KEY
+import me.ahoo.cosec.policy.condition.part.RequestParts
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.util.UUID
+
+class RedisGroupedRateLimiterConditionMatcherTest {
+
+    @Test
+    fun matchAllowsIndependentlyPerGroup() {
+        val conditionMatcher = factory()
+            .create(
+                mapOf(
+                    CONDITION_MATCHER_PART_KEY to RequestParts.REMOTE_IP,
+                    RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 2,
+                    REDIS_RATE_LIMITER_CONDITION_MATCHER_WINDOW_SECONDS_KEY to 5,
+                ).asConfiguration(),
+            )
+        val requestA: Request = mockk {
+            every { remoteIp } returns "ip-a"
+        }
+        val requestB: Request = mockk {
+            every { remoteIp } returns "ip-b"
+        }
+        // windowSeconds=5 -> quota per window is 2*5=10.
+        repeat(WINDOW_QUOTA) {
+            conditionMatcher.match(requestA, mockk()).assert().isTrue()
+        }
+        assertThrows(TooManyRequestsException::class.java) {
+            conditionMatcher.match(requestA, mockk())
+        }
+        // Group B has its own independent quota.
+        conditionMatcher.match(requestB, mockk()).assert().isTrue()
+    }
+
+    companion object {
+        private const val WINDOW_QUOTA = 10
+
+        private lateinit var stringRedisTemplate: StringRedisTemplate
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            val connectionFactory = LettuceConnectionFactory(RedisStandaloneConfiguration())
+            connectionFactory.afterPropertiesSet()
+            stringRedisTemplate = StringRedisTemplate(connectionFactory)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun destroy() {
+            stringRedisTemplate.connectionFactory?.let { (it as LettuceConnectionFactory).destroy() }
+        }
+
+        private fun factory(): RedisGroupedRateLimiterConditionMatcherFactory =
+            // Random key prefix isolates each run: window keys live for 2 windows (10s with
+            // windowSeconds=5), so reuse across runs would leak counters into the next run.
+            RedisGroupedRateLimiterConditionMatcherFactory(
+                stringRedisTemplate,
+                keyPrefix = "test:rl:${UUID.randomUUID()}",
+            )
+    }
+}

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcherTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcherTest.kt
@@ -33,6 +33,15 @@ import java.util.UUID
 class RedisGroupedRateLimiterConditionMatcherTest {
 
     @Test
+    fun createWhenPermitsPerSecondMissing() {
+        assertThrows(IllegalArgumentException::class.java) {
+            factory().create(
+                mapOf(CONDITION_MATCHER_PART_KEY to RequestParts.REMOTE_IP).asConfiguration(),
+            )
+        }
+    }
+
+    @Test
     fun matchAllowsIndependentlyPerGroup() {
         val conditionMatcher = factory()
             .create(

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcherTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcherTest.kt
@@ -43,12 +43,14 @@ class RedisGroupedRateLimiterConditionMatcherTest {
 
     @Test
     fun matchAllowsIndependentlyPerGroup() {
+        // quota = 1e-7 per window: group A's rejection after its first acquire is
+        // independent of where the real-time window boundary falls mid-test, and
+        // group B's empty counters allow its first request regardless of time.
         val conditionMatcher = factory()
             .create(
                 mapOf(
                     CONDITION_MATCHER_PART_KEY to RequestParts.REMOTE_IP,
-                    RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 2,
-                    REDIS_RATE_LIMITER_CONDITION_MATCHER_WINDOW_SECONDS_KEY to 5,
+                    RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 0.0000001,
                 ).asConfiguration(),
             )
         val requestA: Request = mockk {
@@ -57,10 +59,7 @@ class RedisGroupedRateLimiterConditionMatcherTest {
         val requestB: Request = mockk {
             every { remoteIp } returns "ip-b"
         }
-        // windowSeconds=5 -> quota per window is 2*5=10.
-        repeat(WINDOW_QUOTA) {
-            conditionMatcher.match(requestA, mockk()).assert().isTrue()
-        }
+        conditionMatcher.match(requestA, mockk()).assert().isTrue()
         assertThrows(TooManyRequestsException::class.java) {
             conditionMatcher.match(requestA, mockk())
         }
@@ -69,8 +68,6 @@ class RedisGroupedRateLimiterConditionMatcherTest {
     }
 
     companion object {
-        private const val WINDOW_QUOTA = 10
-
         private lateinit var stringRedisTemplate: StringRedisTemplate
 
         @BeforeAll

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcherTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcherTest.kt
@@ -29,6 +29,13 @@ import java.util.UUID
 class RedisRateLimiterConditionMatcherTest {
 
     @Test
+    fun createWhenPermitsPerSecondMissing() {
+        assertThrows(IllegalArgumentException::class.java) {
+            factory().create(emptyMap<String, Any>().asConfiguration())
+        }
+    }
+
+    @Test
     fun matchAllowsRequestsWithinWindowLimit() {
         // windowSeconds=5 -> quota per window is 2*5=10; the larger window keeps the
         // burst-fill assertions robust against scheduler pauses (a gap between calls

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcherTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcherTest.kt
@@ -36,37 +36,19 @@ class RedisRateLimiterConditionMatcherTest {
     }
 
     @Test
-    fun matchAllowsRequestsWithinWindowLimit() {
-        // windowSeconds=5 -> quota per window is 2*5=10; the larger window keeps the
-        // burst-fill assertions robust against scheduler pauses (a gap between calls
-        // only flips the outcome once it exceeds half the window).
+    fun matchThenRejectWhenQuotaExhausted() {
+        // quota = 1e-7 per window: after the first acquire the estimate is at least
+        // one weight step (0.001) above the quota, so the rejection is independent
+        // of where the real-time window boundary falls mid-test. Window-roll decay
+        // semantics are covered deterministically in RedisSlidingWindowRateLimiterTest.
         val conditionMatcher = factory()
             .create(
-                mapOf(
-                    RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 2,
-                    REDIS_RATE_LIMITER_CONDITION_MATCHER_WINDOW_SECONDS_KEY to 5,
-                ).asConfiguration(),
+                mapOf(RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 0.0000001).asConfiguration(),
             )
-        repeat(WINDOW_QUOTA) {
-            conditionMatcher.match(mockk(), mockk()).assert().isTrue()
-        }
-        assertThrows(TooManyRequestsException::class.java) {
-            conditionMatcher.match(mockk(), mockk())
-        }
-    }
-
-    @Test
-    fun matchRecoversAfterWindowRolls() {
-        val conditionMatcher = factory()
-            .create(mapOf(RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 2).asConfiguration())
-        conditionMatcher.match(mockk(), mockk()).assert().isTrue()
         conditionMatcher.match(mockk(), mockk()).assert().isTrue()
         assertThrows(TooManyRequestsException::class.java) {
             conditionMatcher.match(mockk(), mockk())
         }
-        // After the window rolls, the previous window's weight decays and requests are allowed again.
-        Thread.sleep(WINDOW_ROLL_MARGIN_MS)
-        conditionMatcher.match(mockk(), mockk()).assert().isTrue()
     }
 
     @Test
@@ -91,9 +73,6 @@ class RedisRateLimiterConditionMatcherTest {
     }
 
     companion object {
-        private const val WINDOW_ROLL_MARGIN_MS = 1_200L
-        private const val WINDOW_QUOTA = 10
-
         private lateinit var stringRedisTemplate: StringRedisTemplate
         private lateinit var badStringRedisTemplate: StringRedisTemplate
 

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcherTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcherTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.cache.limiter
+
+import io.mockk.mockk
+import me.ahoo.cosec.configuration.JsonConfiguration.Companion.asConfiguration
+import me.ahoo.cosec.policy.condition.limiter.RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY
+import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.util.UUID
+
+class RedisRateLimiterConditionMatcherTest {
+
+    @Test
+    fun matchAllowsRequestsWithinWindowLimit() {
+        // windowSeconds=5 -> quota per window is 2*5=10; the larger window keeps the
+        // burst-fill assertions robust against scheduler pauses (a gap between calls
+        // only flips the outcome once it exceeds half the window).
+        val conditionMatcher = factory()
+            .create(
+                mapOf(
+                    RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 2,
+                    REDIS_RATE_LIMITER_CONDITION_MATCHER_WINDOW_SECONDS_KEY to 5,
+                ).asConfiguration(),
+            )
+        repeat(WINDOW_QUOTA) {
+            conditionMatcher.match(mockk(), mockk()).assert().isTrue()
+        }
+        assertThrows(TooManyRequestsException::class.java) {
+            conditionMatcher.match(mockk(), mockk())
+        }
+    }
+
+    @Test
+    fun matchRecoversAfterWindowRolls() {
+        val conditionMatcher = factory()
+            .create(mapOf(RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 2).asConfiguration())
+        conditionMatcher.match(mockk(), mockk()).assert().isTrue()
+        conditionMatcher.match(mockk(), mockk()).assert().isTrue()
+        assertThrows(TooManyRequestsException::class.java) {
+            conditionMatcher.match(mockk(), mockk())
+        }
+        // After the window rolls, the previous window's weight decays and requests are allowed again.
+        Thread.sleep(WINDOW_ROLL_MARGIN_MS)
+        conditionMatcher.match(mockk(), mockk()).assert().isTrue()
+    }
+
+    @Test
+    fun failOpenWhenRedisUnavailable() {
+        val conditionMatcher = badFactory()
+            .create(mapOf(RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 3).asConfiguration())
+        conditionMatcher.match(mockk(), mockk()).assert().isTrue()
+    }
+
+    @Test
+    fun failClosedWhenRedisUnavailableAndStrict() {
+        val conditionMatcher = badFactory()
+            .create(
+                mapOf(
+                    RATE_LIMITER_CONDITION_MATCHER_PERMITS_PER_SECOND_KEY to 3,
+                    REDIS_RATE_LIMITER_CONDITION_MATCHER_STRICT_FAILURE_KEY to true,
+                ).asConfiguration(),
+            )
+        assertThrows(TooManyRequestsException::class.java) {
+            conditionMatcher.match(mockk(), mockk())
+        }
+    }
+
+    companion object {
+        private const val WINDOW_ROLL_MARGIN_MS = 1_200L
+        private const val WINDOW_QUOTA = 10
+
+        private lateinit var stringRedisTemplate: StringRedisTemplate
+        private lateinit var badStringRedisTemplate: StringRedisTemplate
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            val connectionFactory = LettuceConnectionFactory(RedisStandaloneConfiguration())
+            connectionFactory.afterPropertiesSet()
+            stringRedisTemplate = StringRedisTemplate(connectionFactory)
+
+            val badConnectionFactory = LettuceConnectionFactory(RedisStandaloneConfiguration("127.0.0.1", UNUSED_PORT))
+            badConnectionFactory.afterPropertiesSet()
+            badStringRedisTemplate = StringRedisTemplate(badConnectionFactory)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun destroy() {
+            stringRedisTemplate.connectionFactory?.let { (it as LettuceConnectionFactory).destroy() }
+            badStringRedisTemplate.connectionFactory?.let { (it as LettuceConnectionFactory).destroy() }
+        }
+
+        private fun factory(): RedisRateLimiterConditionMatcherFactory =
+            // Random key prefix isolates each run: window keys live for 2 windows (10s with
+            // windowSeconds=5), so reuse across runs would leak counters into the next run.
+            RedisRateLimiterConditionMatcherFactory(
+                stringRedisTemplate,
+                keyPrefix = "test:rl:${UUID.randomUUID()}",
+            )
+
+        private fun badFactory(): RedisRateLimiterConditionMatcherFactory =
+            RedisRateLimiterConditionMatcherFactory(badStringRedisTemplate)
+
+        private const val UNUSED_PORT = 6_399
+    }
+}

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
@@ -67,7 +67,8 @@ class RedisSlidingWindowRateLimiterTest {
         limiter.tryAcquireInternal("t", 6_000L).assert().isTrue()
         // Same window at t=9000ms: weight = 0.2, estimate = 10*0.2 + 1 = 3 < 10 -> allowed.
         limiter.tryAcquireInternal("t", 9_000L).assert().isTrue()
-        // Window 2 at t=10000ms: estimate = 0 -> allowed.
+        // Window 2 at t=10000ms: previous window holds 2 acquires at weight 1.0,
+        // estimate = 2 < 10 -> allowed.
         limiter.tryAcquireInternal("t", 10_000L).assert().isTrue()
     }
 

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
@@ -114,6 +114,9 @@ class RedisSlidingWindowRateLimiterTest {
         // Quota 1000 in one window; 2000 concurrent acquisitions share the same
         // injected timestamp, so the Lua script is the only arbiter.
         val limiter = rateLimiter(permitsPerSecond = CONCURRENT_QUOTA.toDouble(), windowSeconds = 1)
+        // Preload the script before the burst: on a fresh Redis the first
+        // concurrent EVALSHA can race script loading (see warmUp).
+        RedisSlidingWindowRateLimiter.warmUp(stringRedisTemplate)
         val allowed = AtomicInteger()
         val rejected = AtomicInteger()
         val startLatch = CountDownLatch(1)

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.cache.limiter
+
+import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+/**
+ * Deterministic tests for [RedisSlidingWindowRateLimiter] driven by injected
+ * timestamps, so the sliding-window interpolation math is verified exactly.
+ *
+ * Interpolation semantics: estimate = previousCount * weight + currentCount.
+ * The weight applies ONLY to the previous window, so a window filled to its
+ * quota rejects until the window rolls, and then decays linearly over the
+ * next window.
+ */
+class RedisSlidingWindowRateLimiterTest {
+
+    @Test
+    fun weightDecayAllowsAfterWindowRoll() {
+        // Quota per window: 2/s * 5s = 10.
+        val limiter = rateLimiter(permitsPerSecond = 2.0, windowSeconds = 5)
+        repeat(WINDOW_QUOTA) {
+            limiter.tryAcquireInternal("t", 0L).assert().isTrue()
+        }
+        // Same window (t < 5000ms): currentCount = 10 -> estimate = 0*1 + 10 = 10 >= 10 -> rejected.
+        assertThrows(TooManyRequestsException::class.java) {
+            limiter.tryAcquireInternal("t", 0L)
+        }
+        // Window 1 at t=6000ms: previousCount = 10, weight = (5000-1000)/5000 = 0.8,
+        // estimate = 10*0.8 + 0 = 8 < 10 -> allowed.
+        limiter.tryAcquireInternal("t", 6_000L).assert().isTrue()
+        // Same window at t=9000ms: weight = 0.2, estimate = 10*0.2 + 1 = 3 < 10 -> allowed.
+        limiter.tryAcquireInternal("t", 9_000L).assert().isTrue()
+        // Window 2 at t=10000ms: estimate = 0 -> allowed.
+        limiter.tryAcquireInternal("t", 10_000L).assert().isTrue()
+    }
+
+    @Test
+    fun rejectedRequestsAreNotCounted() {
+        val limiter = rateLimiter(permitsPerSecond = 2.0, windowSeconds = 5)
+        repeat(WINDOW_QUOTA) {
+            limiter.tryAcquireInternal("t", 0L)
+        }
+        // Rejected three times. Had rejections counted, the window would hold 13;
+        // at t=6000ms that would give estimate = 13*0.8 = 10.4 >= 10 -> rejected.
+        // Since they do not count, estimate = 10*0.8 = 8 < 10 -> allowed.
+        repeat(3) {
+            assertThrows(TooManyRequestsException::class.java) {
+                limiter.tryAcquireInternal("t", 0L)
+            }
+        }
+        limiter.tryAcquireInternal("t", 6_000L).assert().isTrue()
+    }
+
+    @Test
+    fun identicalConfigurationsShareQuota() {
+        val prefix = UUID.randomUUID().toString()
+        val limiterA = rateLimiter(permitsPerSecond = 2.0, windowSeconds = 5, prefix = prefix)
+        val limiterB = rateLimiter(permitsPerSecond = 2.0, windowSeconds = 5, prefix = prefix)
+        repeat(WINDOW_QUOTA / 2) {
+            limiterA.tryAcquireInternal("t", 0L).assert().isTrue()
+        }
+        // B consumes the rest of the shared cluster-wide quota.
+        repeat(WINDOW_QUOTA / 2) {
+            limiterB.tryAcquireInternal("t", 0L).assert().isTrue()
+        }
+        assertThrows(TooManyRequestsException::class.java) {
+            limiterA.tryAcquireInternal("t", 0L)
+        }
+        assertThrows(TooManyRequestsException::class.java) {
+            limiterB.tryAcquireInternal("t", 0L)
+        }
+    }
+
+    @Test
+    fun differentConfigurationsAreIsolated() {
+        val prefix = UUID.randomUUID().toString()
+        val limiterA = rateLimiter(permitsPerSecond = 2.0, windowSeconds = 5, prefix = prefix)
+        val limiterB = rateLimiter(permitsPerSecond = 3.0, windowSeconds = 5, prefix = prefix)
+        repeat(WINDOW_QUOTA) {
+            limiterA.tryAcquireInternal("t", 0L).assert().isTrue()
+        }
+        assertThrows(TooManyRequestsException::class.java) {
+            limiterA.tryAcquireInternal("t", 0L)
+        }
+        // Different configuration -> different counters -> B's quota is untouched.
+        limiterB.tryAcquireInternal("t", 0L).assert().isTrue()
+    }
+
+    @Test
+    fun concurrentAcquisitionIsAtomic() {
+        // Quota 1000 in one window; 2000 concurrent acquisitions share the same
+        // injected timestamp, so the Lua script is the only arbiter.
+        val limiter = rateLimiter(permitsPerSecond = CONCURRENT_QUOTA.toDouble(), windowSeconds = 1)
+        val allowed = AtomicInteger()
+        val rejected = AtomicInteger()
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(THREADS)
+        repeat(THREADS) {
+            thread {
+                startLatch.await()
+                repeat(REQUESTS_PER_THREAD) {
+                    try {
+                        limiter.tryAcquireInternal("t", 0L)
+                        allowed.incrementAndGet()
+                    } catch (_: TooManyRequestsException) {
+                        rejected.incrementAndGet()
+                    }
+                }
+                doneLatch.countDown()
+            }
+        }
+        startLatch.countDown()
+        doneLatch.await()
+        (allowed.get() + rejected.get()).assert().isEqualTo(THREADS * REQUESTS_PER_THREAD)
+        // Atomic check-and-count must never overshoot the quota.
+        allowed.get().assert().isLessThanOrEqualTo(CONCURRENT_QUOTA)
+        rejected.get().assert().isGreaterThan(0)
+    }
+
+    companion object {
+        private const val WINDOW_QUOTA = 10
+        private const val CONCURRENT_QUOTA = 1_000
+        private const val THREADS = 10
+        private const val REQUESTS_PER_THREAD = 200
+
+        private lateinit var stringRedisTemplate: StringRedisTemplate
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            val connectionFactory = LettuceConnectionFactory(RedisStandaloneConfiguration())
+            connectionFactory.afterPropertiesSet()
+            stringRedisTemplate = StringRedisTemplate(connectionFactory)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun destroy() {
+            stringRedisTemplate.connectionFactory?.let { (it as LettuceConnectionFactory).destroy() }
+        }
+
+        private fun rateLimiter(
+            permitsPerSecond: Double,
+            windowSeconds: Long,
+            prefix: String = UUID.randomUUID().toString(),
+        ): RedisSlidingWindowRateLimiter =
+            RedisSlidingWindowRateLimiter(
+                stringRedisTemplate = stringRedisTemplate,
+                keyPrefix = "test:rl:$prefix",
+                permitsPerSecond = permitsPerSecond,
+                windowSeconds = windowSeconds,
+                strictFailure = false,
+            )
+    }
+}

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
@@ -113,10 +113,10 @@ class RedisSlidingWindowRateLimiterTest {
     fun concurrentAcquisitionIsAtomic() {
         // Quota 1000 in one window; 2000 concurrent acquisitions share the same
         // injected timestamp, so the Lua script is the only arbiter.
-        val limiter = rateLimiter(permitsPerSecond = CONCURRENT_QUOTA.toDouble(), windowSeconds = 1)
-        // Preload the script before the burst: on a fresh Redis the first
-        // concurrent EVALSHA can race script loading (see warmUp).
-        RedisSlidingWindowRateLimiter.warmUp(stringRedisTemplate)
+        // windowSeconds=20 -> quota 1000 per window with a 40s key TTL. A 1s window (2s TTL)
+        // could expire mid-burst on slow CI runners: the injected clock stays frozen at nowMs=0
+        // while PEXPIRE ticks in real time, resetting the counter and opening a second window.
+        val limiter = rateLimiter(permitsPerSecond = 50.0, windowSeconds = 20)
         val allowed = AtomicInteger()
         val rejected = AtomicInteger()
         val startLatch = CountDownLatch(1)

--- a/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
+++ b/cosec-cocache/src/test/kotlin/me/ahoo/cosec/cache/limiter/RedisSlidingWindowRateLimiterTest.kt
@@ -38,6 +38,20 @@ import kotlin.concurrent.thread
 class RedisSlidingWindowRateLimiterTest {
 
     @Test
+    fun initWhenPermitsPerSecondNotPositive() {
+        assertThrows(IllegalArgumentException::class.java) {
+            rateLimiter(permitsPerSecond = 0.0, windowSeconds = 5)
+        }
+    }
+
+    @Test
+    fun initWhenWindowSecondsBelowOne() {
+        assertThrows(IllegalArgumentException::class.java) {
+            rateLimiter(permitsPerSecond = 2.0, windowSeconds = 0)
+        }
+    }
+
+    @Test
     fun weightDecayAllowsAfterWindowRoll() {
         // Quota per window: 2/s * 5s = 10.
         val limiter = rateLimiter(permitsPerSecond = 2.0, windowSeconds = 5)

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfiguration.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.spring.boot.starter.authorization.limiter
+
+import me.ahoo.cosec.cache.limiter.RedisGroupedRateLimiterConditionMatcherFactory
+import me.ahoo.cosec.cache.limiter.RedisRateLimiterConditionMatcherFactory
+import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.data.redis.core.StringRedisTemplate
+
+/**
+ * CoSec Redis Rate Limiter AutoConfiguration.
+ *
+ * Registers the distributed rate limiter matcher factories as beans, so
+ * [me.ahoo.cosec.spring.boot.starter.policy.MatcherFactoryRegister] wires them
+ * into the matcher providers. Only active when Redis is on the classpath and a
+ * [StringRedisTemplate] bean exists.
+ *
+ * @author ahoo wang
+ */
+@AutoConfiguration
+@AutoConfigureAfter(DataRedisAutoConfiguration::class)
+@ConditionalOnCoSecEnabled
+@ConditionalOnProperty(value = [LimiterProperties.ENABLED_KEY], matchIfMissing = true, havingValue = "true")
+@ConditionalOnClass(name = ["me.ahoo.cosec.cache.limiter.RedisRateLimiterConditionMatcherFactory"])
+@ConditionalOnBean(StringRedisTemplate::class)
+@EnableConfigurationProperties(LimiterProperties::class)
+class CoSecRedisRateLimiterAutoConfiguration(private val limiterProperties: LimiterProperties) {
+
+    @Bean
+    fun redisRateLimiterConditionMatcherFactory(
+        stringRedisTemplate: StringRedisTemplate,
+    ): RedisRateLimiterConditionMatcherFactory {
+        return RedisRateLimiterConditionMatcherFactory(stringRedisTemplate, limiterProperties.keyPrefix)
+    }
+
+    @Bean
+    fun redisGroupedRateLimiterConditionMatcherFactory(
+        stringRedisTemplate: StringRedisTemplate,
+    ): RedisGroupedRateLimiterConditionMatcherFactory {
+        return RedisGroupedRateLimiterConditionMatcherFactory(stringRedisTemplate, limiterProperties.keyPrefix)
+    }
+}

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfiguration.kt
@@ -14,7 +14,9 @@ package me.ahoo.cosec.spring.boot.starter.authorization.limiter
 
 import me.ahoo.cosec.cache.limiter.RedisGroupedRateLimiterConditionMatcherFactory
 import me.ahoo.cosec.cache.limiter.RedisRateLimiterConditionMatcherFactory
+import me.ahoo.cosec.cache.limiter.RedisSlidingWindowRateLimiter
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
+import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -56,5 +58,14 @@ class CoSecRedisRateLimiterAutoConfiguration(private val limiterProperties: Limi
         stringRedisTemplate: StringRedisTemplate,
     ): RedisGroupedRateLimiterConditionMatcherFactory {
         return RedisGroupedRateLimiterConditionMatcherFactory(stringRedisTemplate, limiterProperties.keyPrefix)
+    }
+
+    @Bean
+    fun redisRateLimiterScriptWarmer(stringRedisTemplate: StringRedisTemplate): ApplicationRunner {
+        return ApplicationRunner {
+            // Preload the Lua script at startup so the first concurrent burst never
+            // races script loading on a fresh Redis (see RedisSlidingWindowRateLimiter.warmUp).
+            RedisSlidingWindowRateLimiter.warmUp(stringRedisTemplate)
+        }
     }
 }

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfiguration.kt
@@ -14,9 +14,7 @@ package me.ahoo.cosec.spring.boot.starter.authorization.limiter
 
 import me.ahoo.cosec.cache.limiter.RedisGroupedRateLimiterConditionMatcherFactory
 import me.ahoo.cosec.cache.limiter.RedisRateLimiterConditionMatcherFactory
-import me.ahoo.cosec.cache.limiter.RedisSlidingWindowRateLimiter
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
-import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -58,14 +56,5 @@ class CoSecRedisRateLimiterAutoConfiguration(private val limiterProperties: Limi
         stringRedisTemplate: StringRedisTemplate,
     ): RedisGroupedRateLimiterConditionMatcherFactory {
         return RedisGroupedRateLimiterConditionMatcherFactory(stringRedisTemplate, limiterProperties.keyPrefix)
-    }
-
-    @Bean
-    fun redisRateLimiterScriptWarmer(stringRedisTemplate: StringRedisTemplate): ApplicationRunner {
-        return ApplicationRunner {
-            // Preload the Lua script at startup so the first concurrent burst never
-            // races script loading on a fresh Redis (see RedisSlidingWindowRateLimiter.warmUp).
-            RedisSlidingWindowRateLimiter.warmUp(stringRedisTemplate)
-        }
     }
 }

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.spring.boot.starter.authorization.limiter
+
+import me.ahoo.cosec.cache.limiter.DEFAULT_REDIS_RATE_LIMITER_KEY_PREFIX
+import me.ahoo.cosec.spring.boot.starter.ENABLED_SUFFIX_KEY
+import me.ahoo.cosec.spring.boot.starter.EnabledCapable
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+/**
+ * CoSec Redis Rate Limiter Properties.
+ *
+ * @author ahoo wang
+ */
+@ConfigurationProperties(LimiterProperties.PREFIX)
+data class LimiterProperties(
+    @DefaultValue("true") override var enabled: Boolean = true,
+    @DefaultValue(DEFAULT_REDIS_RATE_LIMITER_KEY_PREFIX) var keyPrefix: String = DEFAULT_REDIS_RATE_LIMITER_KEY_PREFIX,
+) : EnabledCapable {
+    companion object {
+        const val PREFIX: String = "cosec.limiter"
+        const val ENABLED_KEY: String = PREFIX + ENABLED_SUFFIX_KEY
+    }
+}

--- a/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -13,3 +13,4 @@ me.ahoo.cosec.spring.boot.starter.opentelemetry.CoSecOpenTelemetryAutoConfigurat
 me.ahoo.cosec.spring.boot.starter.ip2region.Ip2RegionAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.actuate.CoSecEndpointAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.openapi.CoSecOpenAPIAutoConfiguration
+me.ahoo.cosec.spring.boot.starter.authorization.limiter.CoSecRedisRateLimiterAutoConfiguration

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfigurationTest.kt
@@ -40,6 +40,38 @@ internal class CoSecRedisRateLimiterAutoConfigurationTest {
     }
 
     @Test
+    fun propertiesBindFromConfiguration() {
+        contextRunner
+            .withPropertyValues(
+                "cosec.limiter.key-prefix=my-app:rl",
+            )
+            .withUserConfiguration(
+                DataRedisAutoConfiguration::class.java,
+                CoSecRedisRateLimiterAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                val properties = context.getBean(LimiterProperties::class.java)
+                assertThat(properties.keyPrefix).isEqualTo("my-app:rl")
+                assertThat(properties.enabled).isTrue()
+            }
+    }
+
+    @Test
+    fun notLoadedWhenDisabled() {
+        contextRunner
+            .withPropertyValues("cosec.limiter.enabled=false")
+            .withUserConfiguration(
+                DataRedisAutoConfiguration::class.java,
+                CoSecRedisRateLimiterAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                assertThat(context)
+                    .doesNotHaveBean(CoSecRedisRateLimiterAutoConfiguration::class.java)
+                    .doesNotHaveBean(RedisRateLimiterConditionMatcherFactory::class.java)
+            }
+    }
+
+    @Test
     fun notLoadedWithoutRedisTemplate() {
         contextRunner
             .withUserConfiguration(CoSecRedisRateLimiterAutoConfiguration::class.java)

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/CoSecRedisRateLimiterAutoConfigurationTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.cosec.spring.boot.starter.authorization.limiter
+
+import me.ahoo.cosec.cache.limiter.RedisGroupedRateLimiterConditionMatcherFactory
+import me.ahoo.cosec.cache.limiter.RedisRateLimiterConditionMatcherFactory
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+internal class CoSecRedisRateLimiterAutoConfigurationTest {
+    private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun contextLoadsWithRedis() {
+        contextRunner
+            .withUserConfiguration(
+                DataRedisAutoConfiguration::class.java,
+                CoSecRedisRateLimiterAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                assertThat(context)
+                    .hasSingleBean(LimiterProperties::class.java)
+                    .hasSingleBean(CoSecRedisRateLimiterAutoConfiguration::class.java)
+                    .hasSingleBean(RedisRateLimiterConditionMatcherFactory::class.java)
+                    .hasSingleBean(RedisGroupedRateLimiterConditionMatcherFactory::class.java)
+            }
+    }
+
+    @Test
+    fun notLoadedWithoutRedisTemplate() {
+        contextRunner
+            .withUserConfiguration(CoSecRedisRateLimiterAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                assertThat(context)
+                    .doesNotHaveBean(RedisRateLimiterConditionMatcherFactory::class.java)
+                    .doesNotHaveBean(RedisGroupedRateLimiterConditionMatcherFactory::class.java)
+            }
+    }
+}

--- a/schema/condition.schema.json
+++ b/schema/condition.schema.json
@@ -51,6 +51,12 @@
     },
     "regular": {
       "$ref": "#/definitions/regularConditionMatcher"
+    },
+    "redisRateLimiter": {
+      "$ref": "#/definitions/redisRateLimiterConditionMatcher"
+    },
+    "redisGroupedRateLimiter": {
+      "$ref": "#/definitions/redisGroupedRateLimiterConditionMatcher"
     }
   },
   "maxProperties": 1,
@@ -376,7 +382,46 @@
       },
       "minProperties": 1,
       "additionalProperties": false
+    },
+    "redisRateLimiterConditionMatcher": {
+      "type": "object",
+      "properties": {
+        "permitsPerSecond": {
+          "type": "number"
+        },
+        "windowSeconds": {
+          "type": "integer"
+        },
+        "strictFailure": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "permitsPerSecond"
+      ],
+      "additionalProperties": false
+    },
+    "redisGroupedRateLimiterConditionMatcher": {
+      "type": "object",
+      "properties": {
+        "part": {
+          "$ref": "#/definitions/partValue"
+        },
+        "permitsPerSecond": {
+          "type": "number"
+        },
+        "windowSeconds": {
+          "type": "integer"
+        },
+        "strictFailure": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "part",
+        "permitsPerSecond"
+      ],
+      "additionalProperties": false
     }
   }
 }
-

--- a/wiki/deep-dive/authorization/condition-matchers.md
+++ b/wiki/deep-dive/authorization/condition-matchers.md
@@ -107,8 +107,30 @@ These inspect the security context directly:
 |---------|----------|-------------|
 | [RateLimiterConditionMatcher](cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/limiter/RateLimiterConditionMatcher.kt) | `rateLimiter` | Global rate limiting using Guava `RateLimiter` |
 | [GroupedRateLimiterConditionMatcher](cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/limiter/GroupedRateLimiterConditionMatcher.kt) | `groupedRateLimiter` | Per-group rate limiting (e.g., per-user, per-IP) |
+| [RedisRateLimiterConditionMatcher](cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcher.kt) | `redisRateLimiter` | Cluster-wide rate limiting via Redis (sliding window) |
+| [RedisGroupedRateLimiterConditionMatcher](cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcher.kt) | `redisGroupedRateLimiter` | Cluster-wide per-group rate limiting via Redis |
 
 `RateLimiterConditionMatcher` creates a single rate limiter shared across all requests. `GroupedRateLimiterConditionMatcher` creates a `LoadingCache` of rate limiters keyed by the extracted part value, with automatic expiration after access.
+
+The `rateLimiter` and `groupedRateLimiter` matchers are in-memory only: each instance counts independently, so N instances multiply the effective quota by N. For cluster deployments, use the Redis-backed `redisRateLimiter` / `redisGroupedRateLimiter` matchers instead (requires the `cacheSupport` Gradle feature and Redis). They implement the sliding-window (interpolated counters) algorithm atomically in a single Lua script, so the limit is enforced cluster-wide with O(1) memory per group:
+
+```json
+{
+  "redisRateLimiter": {
+    "permitsPerSecond": 10
+  }
+}
+```
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `permitsPerSecond` | yes | - | Allowed requests per second |
+| `windowSeconds` | no | `1` | Sliding window size; larger windows tolerate bursts (quota per window = `permitsPerSecond * windowSeconds`) |
+| `strictFailure` | no | `false` | `false` fails open (requests pass) when Redis is unreachable; `true` fails closed (rejects with `TooManyRequestsException`) |
+
+Redis key prefix is configurable via `cosec.limiter.key-prefix` (default `cosec:rate-limiter`). Policies with identical limiter configurations share one cluster-wide quota; different configurations are isolated automatically.
+
+> **Important**: the key prefix must be unique per application. Two applications (or prod and staging) sharing one Redis with the same prefix and identical limiter configs will silently share a single quota. Change `cosec.limiter.key-prefix` per deployment.
 
 When a rate limit is exceeded, `TooManyRequestsException` is thrown. CoSec's web filters (`ReactiveSecurityFilter` for WebFlux, `AuthorizationFilter` for WebMVC) catch it and convert the response to `AuthorizeResult.TOO_MANY_REQUESTS`.
 

--- a/wiki/getting-started/configuration.md
+++ b/wiki/getting-started/configuration.md
@@ -129,6 +129,17 @@ The derived Redis key prefix for revoked tokens is `cosec:token:revoked:` (i.e. 
 
 Defined in `CacheProperties` ([cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CacheProperties.kt:34](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CacheProperties.kt#L34)).
 
+### Redis Rate Limiter Properties (`cosec.limiter.*`)
+
+Controls the Redis-backed distributed rate limiter matchers (`redisRateLimiter`, `redisGroupedRateLimiter`).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `cosec.limiter.enabled` | `Boolean` | `true` | Enable the Redis rate limiter matcher factories (registered only when a `StringRedisTemplate` bean exists) |
+| `cosec.limiter.key-prefix` | `String` | `cosec:rate-limiter` | Redis key prefix for limiter counters; **must be unique per application** — identical prefixes on one Redis share a single quota |
+
+Defined in `LimiterProperties` ([cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt:26](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt#L26)).
+
 ### Gateway Properties (`cosec.authorization.gateway.*`)
 
 | Property | Type | Default | Description |

--- a/wiki/zh/deep-dive/authorization/condition-matchers.md
+++ b/wiki/zh/deep-dive/authorization/condition-matchers.md
@@ -107,8 +107,30 @@ fun interface PartExtractor {
 |--------|--------|------|
 | [RateLimiterConditionMatcher](../../../../cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/limiter/RateLimiterConditionMatcher.kt) | `rateLimiter` | 使用 Guava `RateLimiter` 的全局速率限制 |
 | [GroupedRateLimiterConditionMatcher](../../../../cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/limiter/GroupedRateLimiterConditionMatcher.kt) | `groupedRateLimiter` | 按组的速率限制（例如，按用户、按 IP） |
+| [RedisRateLimiterConditionMatcher](../../../../cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisRateLimiterConditionMatcher.kt) | `redisRateLimiter` | 基于 Redis 的集群级速率限制（滑动窗口） |
+| [RedisGroupedRateLimiterConditionMatcher](../../../../cosec-cocache/src/main/kotlin/me/ahoo/cosec/cache/limiter/RedisGroupedRateLimiterConditionMatcher.kt) | `redisGroupedRateLimiter` | 基于 Redis 的集群级按组速率限制 |
 
 `RateLimiterConditionMatcher` 创建一个跨所有请求共享的单个速率限制器。`GroupedRateLimiterConditionMatcher` 创建一个按提取的部分值为键的 `LoadingCache` 速率限制器，访问后自动过期。
+
+`rateLimiter` 与 `groupedRateLimiter` 是纯内存实现：每个实例独立计数，N 个实例会把有效配额放大 N 倍。集群部署请改用基于 Redis 的 `redisRateLimiter` / `redisGroupedRateLimiter`（需要 `cacheSupport` Gradle feature 和 Redis）。它们通过单条 Lua 脚本原子地实现滑动窗口（插值计数）算法，配额在集群范围内生效，每个组的内存开销为 O(1)：
+
+```json
+{
+  "redisRateLimiter": {
+    "permitsPerSecond": 10
+  }
+}
+```
+
+| 键 | 必填 | 默认值 | 描述 |
+|----|------|--------|------|
+| `permitsPerSecond` | 是 | - | 每秒允许的请求数 |
+| `windowSeconds` | 否 | `1` | 滑动窗口大小；更大的窗口容忍突发流量（窗口配额 = `permitsPerSecond * windowSeconds`） |
+| `strictFailure` | 否 | `false` | `false` 时 Redis 不可达则放行（fail-open）；`true` 时拒绝请求（fail-closed，抛 `TooManyRequestsException`） |
+
+Redis key 前缀可通过 `cosec.limiter.key-prefix` 配置（默认 `cosec:rate-limiter`）。配置相同的策略共享同一个集群级配额；配置不同的策略自动隔离。
+
+> **重要**：key 前缀必须按应用唯一。两个应用（或生产/预发环境）共用同一 Redis 且前缀与限流配置相同时，会静默共享同一个配额。每个部署请设置独立的 `cosec.limiter.key-prefix`。
 
 当超出速率限制时，会抛出 `TooManyRequestsException`。CoSec 的 Web 过滤器（WebFlux 的 `ReactiveSecurityFilter`、WebMVC 的 `AuthorizationFilter`）会捕获它并将响应转换为 `AuthorizeResult.TOO_MANY_REQUESTS`。
 

--- a/wiki/zh/getting-started/configuration.md
+++ b/wiki/zh/getting-started/configuration.md
@@ -129,6 +129,17 @@ flowchart TD
 
 定义在 `CacheProperties`（[cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CacheProperties.kt:34](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/cache/CacheProperties.kt#L34)）中。
 
+### Redis 限流器属性（`cosec.limiter.*`）
+
+控制基于 Redis 的分布式限流匹配器（`redisRateLimiter`、`redisGroupedRateLimiter`）。
+
+| 属性 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `cosec.limiter.enabled` | `Boolean` | `true` | 启用 Redis 限流匹配器工厂（仅在存在 `StringRedisTemplate` Bean 时注册） |
+| `cosec.limiter.key-prefix` | `String` | `cosec:rate-limiter` | 限流计数器的 Redis 键前缀；**必须按应用唯一**——同一 Redis 上相同前缀会共享同一个配额 |
+
+定义在 `LimiterProperties`（[cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt:26](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt#L26)）中。
+
 ### 网关属性（`cosec.authorization.gateway.*`）
 
 | 属性 | 类型 | 默认值 | 描述 |


### PR DESCRIPTION
## Summary

Adds cluster-wide distributed rate limiting to close the gap where the existing `rateLimiter`/`groupedRateLimiter` matchers (in-memory Guava) multiply the effective quota by the number of instances.

Two new condition matchers in `cosec-cocache`, registered via Spring auto-configuration:

- `redisRateLimiter` — global distributed rate limit
- `redisGroupedRateLimiter` — per-group distributed rate limit (e.g. `part: request.remoteIp`)

## Design

- **Algorithm**: sliding window with interpolated counters, executed atomically in a single Lua script (`redis-rate-limiter.lua`), O(1) memory per group, no fixed-window boundary burst hole
- **Config**: `permitsPerSecond` (required), `windowSeconds` (default 1, quota per window = `permitsPerSecond × windowSeconds`), `strictFailure` (default `false` = fail-open when Redis is unreachable; `true` = fail-closed with 429)
- **Isolation**: identical limiter configurations share one cluster-wide quota; different configurations are isolated via a config-derived key hash
- **Failure mode**: any Redis failure takes the configured mode; failure logs are rate-limited to one per 10s to avoid log storms during outages
- **Wiring**: factories are Spring beans from `CoSecRedisRateLimiterAutoConfiguration` (`@AutoConfigureAfter(DataRedisAutoConfiguration)`, active only when a `StringRedisTemplate` bean exists); `MatcherFactoryRegister` registers them into the matcher provider — no SPI/services file
- **Properties**: `cosec.limiter.enabled` (default true), `cosec.limiter.key-prefix` (default `cosec:rate-limiter`; must be unique per application on a shared Redis)

## Testing

- Deterministic tests with injected timestamps (`tryAcquireInternal(groupKey, nowMs)`): weight decay after window roll, rejected-requests-not-counted, identical-config quota sharing, different-config isolation, concurrent atomicity (2000 concurrent acquires never overshoot the quota)
- Integration tests against local Redis (CI service container): window limit, recovery after roll, fail-open/fail-closed, per-group independence
- Auto-configuration tests: factories registered with Redis, absent without a `StringRedisTemplate`
- `./gradlew detekt` clean; cosec-cocache / cosec-core / cosec-spring-boot-starter test suites green

## Docs

- `schema/condition.schema.json`: new matcher types
- Wiki (EN/ZH): condition-matchers page, configuration reference for `cosec.limiter.*`