### PR TITLE
feat: add authorization audit log (AuditEventSink/AuditingAuthorization)

### DIFF
--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/audit/AuditEvent.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/audit/AuditEvent.kt
@@ -26,6 +26,18 @@ enum class AuditDecision {
     ERROR,
 }
 
+data class AuditDevice(
+    val id: String?,
+    val userAgent: String?,
+)
+
+data class AuditMatch(
+    val policyId: String? = null,
+    val statementName: String? = null,
+    val roleId: String? = null,
+    val permissionId: String? = null,
+)
+
 /**
  * Structured audit event for a single authorization decision.
  */
@@ -38,7 +50,7 @@ data class AuditEvent(
     val policies: Set<String>,
     val appId: String?,
     val spaceId: String?,
-    val deviceId: String?,
+    val device: AuditDevice,
     val requestId: String?,
     val remoteIp: String,
     val method: String,
@@ -46,10 +58,7 @@ data class AuditEvent(
     val decision: AuditDecision,
     val reason: String,
     val elapsedNanos: Long,
-    val matchedPolicyId: String?,
-    val matchedStatementName: String?,
-    val matchedRoleId: String?,
-    val matchedPermissionId: String?,
+    val match: AuditMatch?,
 )
 
 /**

--- a/cosec-api/src/main/kotlin/me/ahoo/cosec/api/audit/AuditEvent.kt
+++ b/cosec-api/src/main/kotlin/me/ahoo/cosec/api/audit/AuditEvent.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.api.audit
+
+import java.time.Instant
+
+/**
+ * Decision outcome recorded in an [AuditEvent].
+ */
+enum class AuditDecision {
+    ALLOW,
+    EXPLICIT_DENY,
+    IMPLICIT_DENY,
+    TOO_MANY_REQUESTS,
+    ERROR,
+}
+
+/**
+ * Structured audit event for a single authorization decision.
+ */
+data class AuditEvent(
+    val timestamp: Instant,
+    val tenantId: String,
+    val principalId: String,
+    val authenticated: Boolean,
+    val roles: Set<String>,
+    val policies: Set<String>,
+    val appId: String?,
+    val spaceId: String?,
+    val deviceId: String?,
+    val requestId: String?,
+    val remoteIp: String,
+    val method: String,
+    val path: String,
+    val decision: AuditDecision,
+    val reason: String,
+    val elapsedNanos: Long,
+    val matchedPolicyId: String?,
+    val matchedStatementName: String?,
+    val matchedRoleId: String?,
+    val matchedPermissionId: String?,
+)
+
+/**
+ * SPI for consuming audit events.
+ *
+ * Implementations must be non-blocking; thrown exceptions are
+ * swallowed by [me.ahoo.cosec.audit.AuditingAuthorization] and never affect authorization.
+ */
+fun interface AuditEventSink {
+    fun publish(event: AuditEvent)
+}

--- a/cosec-api/src/test/kotlin/me/ahoo/cosec/api/audit/AuditEventTest.kt
+++ b/cosec-api/src/test/kotlin/me/ahoo/cosec/api/audit/AuditEventTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.api.audit
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AuditEventTest {
+    @Test
+    fun auditDecisionValues() {
+        val decisions = AuditDecision.entries.map { it.name }.toSet()
+        decisions.assert().isEqualTo(
+            setOf("ALLOW", "EXPLICIT_DENY", "IMPLICIT_DENY", "TOO_MANY_REQUESTS", "ERROR"),
+        )
+    }
+
+    @Test
+    fun auditEventEquality() {
+        val event = AuditEvent(
+            timestamp = Instant.ofEpochMilli(1),
+            tenantId = "t1",
+            principalId = "u1",
+            authenticated = true,
+            roles = setOf("admin@0"),
+            policies = setOf("p1"),
+            appId = "app",
+            spaceId = "0",
+            deviceId = null,
+            requestId = "req-1",
+            remoteIp = "127.0.0.1",
+            method = "GET",
+            path = "/api",
+            decision = AuditDecision.ALLOW,
+            reason = "Allow",
+            elapsedNanos = 1,
+            matchedPolicyId = null,
+            matchedStatementName = null,
+            matchedRoleId = null,
+            matchedPermissionId = null,
+        )
+        event.copy(path = "/other").assert().isNotEqualTo(event)
+        event.assert().isEqualTo(event.copy())
+    }
+}

--- a/cosec-api/src/test/kotlin/me/ahoo/cosec/api/audit/AuditEventTest.kt
+++ b/cosec-api/src/test/kotlin/me/ahoo/cosec/api/audit/AuditEventTest.kt
@@ -37,7 +37,7 @@ class AuditEventTest {
             policies = setOf("p1"),
             appId = "app",
             spaceId = "0",
-            deviceId = null,
+            device = AuditDevice(id = null, userAgent = "test-agent"),
             requestId = "req-1",
             remoteIp = "127.0.0.1",
             method = "GET",
@@ -45,10 +45,7 @@ class AuditEventTest {
             decision = AuditDecision.ALLOW,
             reason = "Allow",
             elapsedNanos = 1,
-            matchedPolicyId = null,
-            matchedStatementName = null,
-            matchedRoleId = null,
-            matchedPermissionId = null,
+            match = null,
         )
         event.copy(path = "/other").assert().isNotEqualTo(event)
         event.assert().isEqualTo(event.copy())

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
@@ -18,7 +18,6 @@ import me.ahoo.cosec.api.audit.AuditEvent
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
-import me.ahoo.cosec.api.policy.VerifyResult
 import me.ahoo.cosec.authorization.PolicyVerifyContext
 import me.ahoo.cosec.authorization.RoleVerifyContext
 import me.ahoo.cosec.authorization.VerifyContext.Companion.getVerifyContext
@@ -41,7 +40,7 @@ object AuditEventExtractor {
         return eventOf(
             request = request,
             context = context,
-            decision = toDecision(context, result),
+            decision = toDecision(result),
             reason = result.reason,
             elapsedNanos = elapsedNanos,
             verifyContext = verifyContext,
@@ -62,17 +61,13 @@ object AuditEventExtractor {
         return eventOf(request, context, decision, reason, elapsedNanos, verifyContext = context.getVerifyContext())
     }
 
-    private fun toDecision(context: SecurityContext, result: AuthorizeResult): AuditDecision {
-        if (result.authorized) {
-            return AuditDecision.ALLOW
+    private fun toDecision(result: AuthorizeResult): AuditDecision {
+        return when {
+            result.authorized -> AuditDecision.ALLOW
+            AuthorizeResult.TOO_MANY_REQUESTS.reason == result.reason -> AuditDecision.TOO_MANY_REQUESTS
+            AuthorizeResult.IMPLICIT_DENY.reason == result.reason -> AuditDecision.IMPLICIT_DENY
+            else -> AuditDecision.EXPLICIT_DENY
         }
-        if (context.getVerifyContext()?.result == VerifyResult.EXPLICIT_DENY) {
-            return AuditDecision.EXPLICIT_DENY
-        }
-        if (AuthorizeResult.IMPLICIT_DENY.reason == result.reason) {
-            return AuditDecision.IMPLICIT_DENY
-        }
-        return AuditDecision.EXPLICIT_DENY
     }
 
     private fun eventOf(
@@ -105,8 +100,8 @@ object AuditEventExtractor {
             tenantId = context.tenant.tenantId,
             principalId = context.principal.id,
             authenticated = context.principal.authenticated,
-            roles = context.principal.roles,
-            policies = context.principal.policies,
+            roles = context.principal.roles.toSet(),
+            policies = context.principal.policies.toSet(),
             appId = request.appId.ifBlank { null },
             spaceId = request.spaceId.ifBlank { null },
             deviceId = request.deviceId.ifBlank { null },

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
@@ -14,7 +14,9 @@
 package me.ahoo.cosec.audit
 
 import me.ahoo.cosec.api.audit.AuditDecision
+import me.ahoo.cosec.api.audit.AuditDevice
 import me.ahoo.cosec.api.audit.AuditEvent
+import me.ahoo.cosec.api.audit.AuditMatch
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
@@ -78,22 +80,18 @@ object AuditEventExtractor {
         elapsedNanos: Long,
         verifyContext: me.ahoo.cosec.authorization.VerifyContext?,
     ): AuditEvent {
-        var matchedPolicyId: String? = null
-        var matchedStatementName: String? = null
-        var matchedRoleId: String? = null
-        var matchedPermissionId: String? = null
-        when (verifyContext) {
-            is PolicyVerifyContext -> {
-                matchedPolicyId = verifyContext.policy.id
-                matchedStatementName = verifyContext.statement.name
-            }
+        val match = when (verifyContext) {
+            is PolicyVerifyContext -> AuditMatch(
+                policyId = verifyContext.policy.id,
+                statementName = verifyContext.statement.name,
+            )
 
-            is RoleVerifyContext -> {
-                matchedRoleId = verifyContext.roleId
-                matchedPermissionId = verifyContext.permission.id
-            }
+            is RoleVerifyContext -> AuditMatch(
+                roleId = verifyContext.roleId,
+                permissionId = verifyContext.permission.id,
+            )
 
-            null -> Unit
+            else -> null
         }
         return AuditEvent(
             timestamp = Instant.now(),
@@ -104,7 +102,10 @@ object AuditEventExtractor {
             policies = context.principal.policies.toSet(),
             appId = request.appId.ifBlank { null },
             spaceId = request.spaceId.ifBlank { null },
-            deviceId = request.deviceId.ifBlank { null },
+            device = AuditDevice(
+                id = request.deviceId.ifBlank { null },
+                userAgent = request.getHeader(USER_AGENT_HEADER).ifBlank { null },
+            ),
             requestId = request.requestId.ifBlank { null },
             remoteIp = request.remoteIp,
             method = request.method,
@@ -112,10 +113,9 @@ object AuditEventExtractor {
             decision = decision,
             reason = reason,
             elapsedNanos = elapsedNanos,
-            matchedPolicyId = matchedPolicyId,
-            matchedStatementName = matchedStatementName,
-            matchedRoleId = matchedRoleId,
-            matchedPermissionId = matchedPermissionId,
+            match = match,
         )
     }
+
+    private const val USER_AGENT_HEADER = "User-Agent"
 }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
@@ -22,6 +22,7 @@ import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
 import me.ahoo.cosec.authorization.PolicyVerifyContext
 import me.ahoo.cosec.authorization.RoleVerifyContext
+import me.ahoo.cosec.authorization.VerifyContext
 import me.ahoo.cosec.authorization.VerifyContext.Companion.getVerifyContext
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
 import me.ahoo.cosec.policy.condition.part.RegexTimeoutException
@@ -37,8 +38,8 @@ object AuditEventExtractor {
         context: SecurityContext,
         result: AuthorizeResult,
         elapsedNanos: Long,
+        verifyContext: VerifyContext? = context.getVerifyContext(),
     ): AuditEvent {
-        val verifyContext = context.getVerifyContext()
         return eventOf(
             request = request,
             context = context,
@@ -54,13 +55,14 @@ object AuditEventExtractor {
         context: SecurityContext,
         error: Throwable,
         elapsedNanos: Long,
+        verifyContext: VerifyContext? = context.getVerifyContext(),
     ): AuditEvent {
         val (decision, reason) = when (error) {
             is TooManyRequestsException -> AuditDecision.TOO_MANY_REQUESTS to AuthorizeResult.TOO_MANY_REQUESTS.reason
             is RegexTimeoutException -> AuditDecision.IMPLICIT_DENY to AuthorizeResult.IMPLICIT_DENY.reason
             else -> AuditDecision.ERROR to error.javaClass.simpleName
         }
-        return eventOf(request, context, decision, reason, elapsedNanos, verifyContext = context.getVerifyContext())
+        return eventOf(request, context, decision, reason, elapsedNanos, verifyContext)
     }
 
     private fun toDecision(result: AuthorizeResult): AuditDecision {
@@ -78,7 +80,7 @@ object AuditEventExtractor {
         decision: AuditDecision,
         reason: String,
         elapsedNanos: Long,
-        verifyContext: me.ahoo.cosec.authorization.VerifyContext?,
+        verifyContext: VerifyContext?,
     ): AuditEvent {
         val match = when (verifyContext) {
             is PolicyVerifyContext -> AuditMatch(

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
@@ -23,6 +23,7 @@ import me.ahoo.cosec.authorization.PolicyVerifyContext
 import me.ahoo.cosec.authorization.RoleVerifyContext
 import me.ahoo.cosec.authorization.VerifyContext.Companion.getVerifyContext
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import me.ahoo.cosec.policy.condition.part.RegexTimeoutException
 import java.time.Instant
 
 /**
@@ -53,13 +54,10 @@ object AuditEventExtractor {
         error: Throwable,
         elapsedNanos: Long,
     ): AuditEvent {
-        val decision = when (error) {
-            is TooManyRequestsException -> AuditDecision.TOO_MANY_REQUESTS
-            else -> AuditDecision.ERROR
-        }
-        val reason = when (error) {
-            is TooManyRequestsException -> AuthorizeResult.TOO_MANY_REQUESTS.reason
-            else -> error.javaClass.simpleName
+        val (decision, reason) = when (error) {
+            is TooManyRequestsException -> AuditDecision.TOO_MANY_REQUESTS to AuthorizeResult.TOO_MANY_REQUESTS.reason
+            is RegexTimeoutException -> AuditDecision.IMPLICIT_DENY to AuthorizeResult.IMPLICIT_DENY.reason
+            else -> AuditDecision.ERROR to error.javaClass.simpleName
         }
         return eventOf(request, context, decision, reason, elapsedNanos, verifyContext = context.getVerifyContext())
     }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.audit
+
+import me.ahoo.cosec.api.audit.AuditDecision
+import me.ahoo.cosec.api.audit.AuditEvent
+import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.api.policy.VerifyResult
+import me.ahoo.cosec.authorization.PolicyVerifyContext
+import me.ahoo.cosec.authorization.RoleVerifyContext
+import me.ahoo.cosec.authorization.VerifyContext.Companion.getVerifyContext
+import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import java.time.Instant
+
+/**
+ * Maps an authorization outcome to an [AuditEvent].
+ */
+object AuditEventExtractor {
+
+    fun fromDecision(
+        request: Request,
+        context: SecurityContext,
+        result: AuthorizeResult,
+        elapsedNanos: Long,
+    ): AuditEvent {
+        val verifyContext = context.getVerifyContext()
+        return eventOf(
+            request = request,
+            context = context,
+            decision = toDecision(context, result),
+            reason = result.reason,
+            elapsedNanos = elapsedNanos,
+            verifyContext = verifyContext,
+        )
+    }
+
+    fun fromError(
+        request: Request,
+        context: SecurityContext,
+        error: Throwable,
+        elapsedNanos: Long,
+    ): AuditEvent {
+        val decision = when (error) {
+            is TooManyRequestsException -> AuditDecision.TOO_MANY_REQUESTS
+            else -> AuditDecision.ERROR
+        }
+        val reason = when (error) {
+            is TooManyRequestsException -> AuthorizeResult.TOO_MANY_REQUESTS.reason
+            else -> error.javaClass.simpleName
+        }
+        return eventOf(request, context, decision, reason, elapsedNanos, verifyContext = context.getVerifyContext())
+    }
+
+    private fun toDecision(context: SecurityContext, result: AuthorizeResult): AuditDecision {
+        if (result.authorized) {
+            return AuditDecision.ALLOW
+        }
+        if (context.getVerifyContext()?.result == VerifyResult.EXPLICIT_DENY) {
+            return AuditDecision.EXPLICIT_DENY
+        }
+        if (AuthorizeResult.IMPLICIT_DENY.reason == result.reason) {
+            return AuditDecision.IMPLICIT_DENY
+        }
+        return AuditDecision.EXPLICIT_DENY
+    }
+
+    private fun eventOf(
+        request: Request,
+        context: SecurityContext,
+        decision: AuditDecision,
+        reason: String,
+        elapsedNanos: Long,
+        verifyContext: me.ahoo.cosec.authorization.VerifyContext?,
+    ): AuditEvent {
+        var matchedPolicyId: String? = null
+        var matchedStatementName: String? = null
+        var matchedRoleId: String? = null
+        var matchedPermissionId: String? = null
+        when (verifyContext) {
+            is PolicyVerifyContext -> {
+                matchedPolicyId = verifyContext.policy.id
+                matchedStatementName = verifyContext.statement.name
+            }
+
+            is RoleVerifyContext -> {
+                matchedRoleId = verifyContext.roleId
+                matchedPermissionId = verifyContext.permission.id
+            }
+
+            null -> Unit
+        }
+        return AuditEvent(
+            timestamp = Instant.now(),
+            tenantId = context.tenant.tenantId,
+            principalId = context.principal.id,
+            authenticated = context.principal.authenticated,
+            roles = context.principal.roles,
+            policies = context.principal.policies,
+            appId = request.appId.ifBlank { null },
+            spaceId = request.spaceId.ifBlank { null },
+            deviceId = request.deviceId.ifBlank { null },
+            requestId = request.requestId.ifBlank { null },
+            remoteIp = request.remoteIp,
+            method = request.method,
+            path = request.path,
+            decision = decision,
+            reason = reason,
+            elapsedNanos = elapsedNanos,
+            matchedPolicyId = matchedPolicyId,
+            matchedStatementName = matchedStatementName,
+            matchedRoleId = matchedRoleId,
+            matchedPermissionId = matchedPermissionId,
+        )
+    }
+}

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
@@ -23,8 +23,9 @@ import me.ahoo.cosec.api.context.request.Request
 import reactor.core.publisher.Mono
 
 /**
- * [Authorization] decorator that publishes an audit event for every decision,
- * without altering the delegated result or error signals.
+ * [Authorization] decorator that publishes an audit event for every decision.
+ * Every audit step (event construction and publishing) is failure-isolated
+ * and never alters the delegated result or error signals.
  */
 class AuditingAuthorization(
     override val delegate: Authorization,
@@ -37,32 +38,32 @@ class AuditingAuthorization(
             val startNanos = System.nanoTime()
             delegate.authorize(request = request, context = context)
                 .doOnNext { result ->
-                    publishSafely(
+                    publishSafely {
                         AuditEventExtractor.fromDecision(
                             request = request,
                             context = context,
                             result = result,
                             elapsedNanos = System.nanoTime() - startNanos,
-                        ),
-                    )
+                        )
+                    }
                 }
                 .doOnError { error ->
-                    publishSafely(
+                    publishSafely {
                         AuditEventExtractor.fromError(
                             request = request,
                             context = context,
                             error = error,
                             elapsedNanos = System.nanoTime() - startNanos,
-                        ),
-                    )
+                        )
+                    }
                 }
         }
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun publishSafely(event: me.ahoo.cosec.api.audit.AuditEvent) {
+    private inline fun publishSafely(eventSupplier: () -> me.ahoo.cosec.api.audit.AuditEvent) {
         try {
-            auditEventSink.publish(event)
+            auditEventSink.publish(eventSupplier())
         } catch (e: Exception) {
             log.warn(e) { "Failed to publish audit event." }
         }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.audit
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.cosec.Delegated
+import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.api.authorization.Authorization
+import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.Request
+import reactor.core.publisher.Mono
+
+/**
+ * [Authorization] decorator that publishes an audit event for every decision,
+ * without altering the delegated result or error signals.
+ */
+class AuditingAuthorization(
+    override val delegate: Authorization,
+    private val auditEventSink: AuditEventSink,
+) : Authorization,
+    Delegated<Authorization> {
+
+    override fun authorize(request: Request, context: SecurityContext): Mono<AuthorizeResult> {
+        return Mono.defer {
+            val startNanos = System.nanoTime()
+            delegate.authorize(request = request, context = context)
+                .doOnNext { result ->
+                    publishSafely(
+                        AuditEventExtractor.fromDecision(
+                            request = request,
+                            context = context,
+                            result = result,
+                            elapsedNanos = System.nanoTime() - startNanos,
+                        ),
+                    )
+                }
+                .doOnError { error ->
+                    publishSafely(
+                        AuditEventExtractor.fromError(
+                            request = request,
+                            context = context,
+                            error = error,
+                            elapsedNanos = System.nanoTime() - startNanos,
+                        ),
+                    )
+                }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun publishSafely(event: me.ahoo.cosec.api.audit.AuditEvent) {
+        try {
+            auditEventSink.publish(event)
+        } catch (e: Exception) {
+            log.warn(e) { "Failed to publish audit event." }
+        }
+    }
+
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+}

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
@@ -36,7 +36,7 @@ class AuditingAuthorization(
     override fun authorize(request: Request, context: SecurityContext): Mono<AuthorizeResult> {
         return Mono.defer {
             val startNanos = System.nanoTime()
-            delegate.authorize(request = request, context = context)
+            Mono.defer { delegate.authorize(request = request, context = context) }
                 .doOnNext { result ->
                     publishSafely {
                         AuditEventExtractor.fromDecision(

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
@@ -20,6 +20,9 @@ import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.authorization.VerifyContext.Companion.clearVerifyContext
+import me.ahoo.cosec.token.TokenVerificationContexts.getTokenVerificationException
+import me.ahoo.cosec.token.toAuthorizeResult
 import reactor.core.publisher.Mono
 
 /**
@@ -36,13 +39,19 @@ class AuditingAuthorization(
     override fun authorize(request: Request, context: SecurityContext): Mono<AuthorizeResult> {
         return Mono.defer {
             val startNanos = System.nanoTime()
+            context.clearVerifyContext()
             Mono.defer { delegate.authorize(request = request, context = context) }
-                .doOnNext { result ->
+                .doOnSuccess { result ->
                     publishSafely {
+                        val effectiveResult = when {
+                            result == null -> AuthorizeResult.IMPLICIT_DENY
+                            result.authorized -> result
+                            else -> context.getTokenVerificationException()?.toAuthorizeResult() ?: result
+                        }
                         AuditEventExtractor.fromDecision(
                             request = request,
                             context = context,
-                            result = result,
+                            result = effectiveResult,
                             elapsedNanos = System.nanoTime() - startNanos,
                         )
                     }

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
@@ -20,7 +20,7 @@ import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
-import me.ahoo.cosec.authorization.VerifyContext.Companion.clearVerifyContext
+import me.ahoo.cosec.authorization.VerifyContextScope
 import me.ahoo.cosec.token.TokenVerificationContexts.getTokenVerificationException
 import me.ahoo.cosec.token.toAuthorizeResult
 import reactor.core.publisher.Mono
@@ -39,7 +39,7 @@ class AuditingAuthorization(
     override fun authorize(request: Request, context: SecurityContext): Mono<AuthorizeResult> {
         return Mono.defer {
             val startNanos = System.nanoTime()
-            context.clearVerifyContext()
+            val verifyContextScope = VerifyContextScope()
             Mono.defer { delegate.authorize(request = request, context = context) }
                 .doOnSuccess { result ->
                     publishSafely {
@@ -53,6 +53,7 @@ class AuditingAuthorization(
                             context = context,
                             result = effectiveResult,
                             elapsedNanos = System.nanoTime() - startNanos,
+                            verifyContext = verifyContextScope.value,
                         )
                     }
                 }
@@ -63,9 +64,11 @@ class AuditingAuthorization(
                             context = context,
                             error = error,
                             elapsedNanos = System.nanoTime() - startNanos,
+                            verifyContext = verifyContextScope.value,
                         )
                     }
                 }
+                .contextWrite { it.put(VerifyContextScope::class.java, verifyContextScope) }
         }
     }
 

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/LoggingAuditEventSink.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/LoggingAuditEventSink.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.audit
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.cosec.api.audit.AuditDecision
+import me.ahoo.cosec.api.audit.AuditEvent
+import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.serialization.CoSecJsonSerializer
+
+/**
+ * Default [AuditEventSink] writing single-line JSON to the logger named
+ * [LOGGER_NAME]. DENY/TOO_MANY_REQUESTS log at WARN, ERROR at ERROR, ALLOW at DEBUG,
+ * so default INFO level only surfaces denials.
+ */
+class LoggingAuditEventSink(
+    private val logger: KLogger = KotlinLogging.logger(LoggingAuditEventSink.LOGGER_NAME),
+) : AuditEventSink {
+
+    override fun publish(event: AuditEvent) {
+        when (event.decision) {
+            AuditDecision.ALLOW -> logger.debug { CoSecJsonSerializer.writeValueAsString(event) }
+            AuditDecision.EXPLICIT_DENY,
+            AuditDecision.IMPLICIT_DENY,
+            AuditDecision.TOO_MANY_REQUESTS,
+            -> logger.warn { CoSecJsonSerializer.writeValueAsString(event) }
+
+            AuditDecision.ERROR -> logger.error { CoSecJsonSerializer.writeValueAsString(event) }
+        }
+    }
+
+    companion object {
+        const val LOGGER_NAME: String = "me.ahoo.cosec.audit"
+    }
+}

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/PolicyVerifyContext.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/PolicyVerifyContext.kt
@@ -42,15 +42,15 @@ interface VerifyContext {
             this.setAttributeValue(KEY, verifyContext)
         }
 
-        fun SecurityContext.clearVerifyContext() {
-            attributes.remove(KEY)
-        }
-
         /**
          * Gets the verification context from a security context.
          */
         fun SecurityContext.getVerifyContext(): VerifyContext? = this.getAttributeValue(KEY)
     }
+}
+
+internal class VerifyContextScope {
+    var value: VerifyContext? = null
 }
 
 /**

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/PolicyVerifyContext.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/PolicyVerifyContext.kt
@@ -42,6 +42,10 @@ interface VerifyContext {
             this.setAttributeValue(KEY, verifyContext)
         }
 
+        fun SecurityContext.clearVerifyContext() {
+            attributes.remove(KEY)
+        }
+
         /**
          * Gets the verification context from a security context.
          */

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/authorization/SimpleAuthorization.kt
@@ -202,7 +202,7 @@ class SimpleAuthorization(
     private fun verify(
         request: Request,
         context: SecurityContext
-    ): Mono<AuthorizeResult> =
+    ): Mono<AuthorizeResult> = Mono.deferContextual { reactorContext ->
         verifyGlobalPolicies(request, context)
             .switchIfEmpty {
                 verifyPrincipalPolicies(request, context)
@@ -210,6 +210,8 @@ class SimpleAuthorization(
                 verifyAppRolePermission(request, context)
             }.map {
                 context.setVerifyContext(it)
+                reactorContext.getOrEmpty<VerifyContextScope>(VerifyContextScope::class.java)
+                    .ifPresent { scope -> scope.value = it }
                 it.result.toAuthorizeResult()
             }.switchIfEmpty {
                 log.debug {
@@ -217,6 +219,7 @@ class SimpleAuthorization(
                 }
                 AuthorizeResult.IMPLICIT_DENY.toMono()
             }
+    }
 
     override fun authorize(
         request: Request,

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/token/TokenVerificationException.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/token/TokenVerificationException.kt
@@ -15,6 +15,7 @@ package me.ahoo.cosec.token
 
 import me.ahoo.cosec.CoSecException
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.SecurityContext
 
 /**
  * Exception thrown when token verification fails.
@@ -40,4 +41,16 @@ fun TokenVerificationException.toAuthorizeResult(): AuthorizeResult {
         return AuthorizeResult.TOKEN_EXPIRED
     }
     return AuthorizeResult.deny("Token Invalid")
+}
+
+object TokenVerificationContexts {
+    private const val KEY = "COSEC_TOKEN_VERIFICATION_EXCEPTION"
+
+    fun SecurityContext.setTokenVerificationException(exception: TokenVerificationException): SecurityContext {
+        return setAttributeValue(KEY, exception)
+    }
+
+    fun SecurityContext.getTokenVerificationException(): TokenVerificationException? {
+        return getAttributeValue(KEY)
+    }
 }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditEventExtractorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditEventExtractorTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.audit
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.api.permission.Permission
+import me.ahoo.cosec.api.policy.Policy
+import me.ahoo.cosec.api.policy.Statement
+import me.ahoo.cosec.api.policy.VerifyResult
+import me.ahoo.cosec.api.principal.CoSecPrincipal
+import me.ahoo.cosec.api.tenant.Tenant
+import me.ahoo.cosec.authorization.PolicyVerifyContext
+import me.ahoo.cosec.authorization.RoleVerifyContext
+import me.ahoo.cosec.authorization.VerifyContext.Companion.setVerifyContext
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AuditEventExtractorTest {
+    private val request = mockk<Request> {
+        every { appId } returns "app"
+        every { spaceId } returns "0"
+        every { deviceId } returns ""
+        every { requestId } returns "req-1"
+        every { remoteIp } returns "1.2.3.4"
+        every { method } returns "POST"
+        every { path } returns "/api/orders"
+    }
+    private val principal = mockk<CoSecPrincipal> {
+        every { id } returns "u1"
+        every { authenticated } returns true
+        every { roles } returns setOf("admin@0")
+        every { policies } returns setOf("p1")
+    }
+    private val attributeMap = mutableMapOf<String, Any>()
+    private val context = mockk<SecurityContext> {
+        every { principal } returns this@AuditEventExtractorTest.principal
+        every { tenant } returns mockk<Tenant> { every { tenantId } returns "t1" }
+        every { attributes } returns this@AuditEventExtractorTest.attributeMap
+        every { setAttributeValue(any(), any()) } answers {
+            attributeMap[firstArg()] = secondArg()
+            self as SecurityContext
+        }
+        every { getAttributeValue<Any>(any()) } answers { attributeMap[firstArg()] }
+    }
+
+    @Test
+    fun fromDecisionWhenAllow() {
+        val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.ALLOW, elapsedNanos = 100)
+        event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.ALLOW)
+        event.reason.assert().isEqualTo("Allow")
+        event.elapsedNanos.assert().isEqualTo(100)
+        event.deviceId.assert().isNull()
+        event.tenantId.assert().isEqualTo("t1")
+        event.principalId.assert().isEqualTo("u1")
+        event.roles.assert().isEqualTo(setOf("admin@0"))
+        Instant.ofEpochMilli(0).assert().isBefore(event.timestamp)
+    }
+
+    @Test
+    fun fromDecisionWhenExplicitDenyWithPolicyVerifyContext() {
+        val policy = mockk<Policy> { every { id } returns "deny-write" }
+        val statement = mockk<Statement> { every { name } returns "deny-orders-write" }
+        context.setVerifyContext(
+            PolicyVerifyContext(policy, statementIndex = 0, statement = statement, result = VerifyResult.EXPLICIT_DENY),
+        )
+        val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.EXPLICIT_DENY, elapsedNanos = 1)
+        event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.EXPLICIT_DENY)
+        event.matchedPolicyId.assert().isEqualTo("deny-write")
+        event.matchedStatementName.assert().isEqualTo("deny-orders-write")
+        event.matchedRoleId.assert().isNull()
+    }
+
+    @Test
+    fun fromDecisionWhenRoleVerifyContext() {
+        val permission = mockk<Permission> { every { id } returns "permissionId" }
+        context.setVerifyContext(
+            RoleVerifyContext(roleId = "admin", permission = permission, result = VerifyResult.ALLOW)
+        )
+        val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.ALLOW, elapsedNanos = 1)
+        event.matchedRoleId.assert().isEqualTo("admin")
+        event.matchedPermissionId.assert().isEqualTo("permissionId")
+        event.matchedPolicyId.assert().isNull()
+    }
+
+    @Test
+    fun fromDecisionWhenImplicitDeny() {
+        val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.IMPLICIT_DENY, elapsedNanos = 1)
+        event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.IMPLICIT_DENY)
+    }
+
+    @Test
+    fun fromDecisionWhenTokenExpiredCollapsesToExplicitDeny() {
+        val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.TOKEN_EXPIRED, elapsedNanos = 1)
+        event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.EXPLICIT_DENY)
+        event.reason.assert().isEqualTo("Token Expired")
+    }
+
+    @Test
+    fun fromErrorWhenTooManyRequests() {
+        val event = AuditEventExtractor.fromError(
+            request,
+            context,
+            me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException(),
+            elapsedNanos = 1,
+        )
+        event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.TOO_MANY_REQUESTS)
+        event.reason.assert().isEqualTo("Too Many Requests")
+    }
+
+    @Test
+    fun fromErrorWhenUnexpected() {
+        val event = AuditEventExtractor.fromError(request, context, IllegalStateException("boom"), elapsedNanos = 1)
+        event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.ERROR)
+        event.reason.assert().isEqualTo("IllegalStateException")
+    }
+}

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditEventExtractorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditEventExtractorTest.kt
@@ -41,6 +41,7 @@ class AuditEventExtractorTest {
         every { remoteIp } returns "1.2.3.4"
         every { method } returns "POST"
         every { path } returns "/api/orders"
+        every { getHeader("User-Agent") } returns "test-agent"
     }
     private val principal = mockk<CoSecPrincipal> {
         every { id } returns "u1"
@@ -66,7 +67,8 @@ class AuditEventExtractorTest {
         event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.ALLOW)
         event.reason.assert().isEqualTo("Allow")
         event.elapsedNanos.assert().isEqualTo(100)
-        event.deviceId.assert().isNull()
+        event.device.id.assert().isNull()
+        event.device.userAgent.assert().isEqualTo("test-agent")
         event.tenantId.assert().isEqualTo("t1")
         event.principalId.assert().isEqualTo("u1")
         event.roles.assert().isEqualTo(setOf("admin@0"))
@@ -82,9 +84,9 @@ class AuditEventExtractorTest {
         )
         val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.EXPLICIT_DENY, elapsedNanos = 1)
         event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.EXPLICIT_DENY)
-        event.matchedPolicyId.assert().isEqualTo("deny-write")
-        event.matchedStatementName.assert().isEqualTo("deny-orders-write")
-        event.matchedRoleId.assert().isNull()
+        event.match?.policyId.assert().isEqualTo("deny-write")
+        event.match?.statementName.assert().isEqualTo("deny-orders-write")
+        event.match?.roleId.assert().isNull()
     }
 
     @Test
@@ -94,9 +96,9 @@ class AuditEventExtractorTest {
             RoleVerifyContext(roleId = "admin", permission = permission, result = VerifyResult.ALLOW)
         )
         val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.ALLOW, elapsedNanos = 1)
-        event.matchedRoleId.assert().isEqualTo("admin")
-        event.matchedPermissionId.assert().isEqualTo("permissionId")
-        event.matchedPolicyId.assert().isNull()
+        event.match?.roleId.assert().isEqualTo("admin")
+        event.match?.permissionId.assert().isEqualTo("permissionId")
+        event.match?.policyId.assert().isNull()
     }
 
     @Test

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditEventExtractorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditEventExtractorTest.kt
@@ -27,6 +27,7 @@ import me.ahoo.cosec.api.tenant.Tenant
 import me.ahoo.cosec.authorization.PolicyVerifyContext
 import me.ahoo.cosec.authorization.RoleVerifyContext
 import me.ahoo.cosec.authorization.VerifyContext.Companion.setVerifyContext
+import me.ahoo.cosec.policy.condition.part.RegexTimeoutException
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -121,6 +122,13 @@ class AuditEventExtractorTest {
         )
         event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.TOO_MANY_REQUESTS)
         event.reason.assert().isEqualTo("Too Many Requests")
+    }
+
+    @Test
+    fun fromErrorWhenRegexTimeout() {
+        val event = AuditEventExtractor.fromError(request, context, RegexTimeoutException("timeout"), elapsedNanos = 1)
+        event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.IMPLICIT_DENY)
+        event.reason.assert().isEqualTo("Implicit Deny")
     }
 
     @Test

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditEventExtractorTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditEventExtractorTest.kt
@@ -106,6 +106,30 @@ class AuditEventExtractorTest {
     }
 
     @Test
+    fun fromDecisionWhenTooManyRequests() {
+        val event = AuditEventExtractor.fromDecision(
+            request,
+            context,
+            AuthorizeResult.TOO_MANY_REQUESTS,
+            elapsedNanos = 1,
+        )
+        event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.TOO_MANY_REQUESTS)
+    }
+
+    @Test
+    fun snapshotPrincipalGrants() {
+        val roles = mutableSetOf("admin@0")
+        val policies = mutableSetOf("p1")
+        every { principal.roles } returns roles
+        every { principal.policies } returns policies
+        val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.ALLOW, elapsedNanos = 1)
+        roles += "operator@0"
+        policies += "p2"
+        event.roles.assert().isEqualTo(setOf("admin@0"))
+        event.policies.assert().isEqualTo(setOf("p1"))
+    }
+
+    @Test
     fun fromDecisionWhenTokenExpiredCollapsesToExplicitDeny() {
         val event = AuditEventExtractor.fromDecision(request, context, AuthorizeResult.TOKEN_EXPIRED, elapsedNanos = 1)
         event.decision.assert().isEqualTo(me.ahoo.cosec.api.audit.AuditDecision.EXPLICIT_DENY)

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
@@ -47,6 +47,7 @@ class AuditingAuthorizationTest {
         every { remoteIp } returns "1.2.3.4"
         every { method } returns "POST"
         every { path } returns "/api/orders"
+        every { getHeader("User-Agent") } returns "test-agent"
     }
     private val context = mockk<SecurityContext> {
         every { tenant.tenantId } returns "t1"
@@ -115,8 +116,7 @@ class AuditingAuthorizationTest {
         authorization.authorize(request, context).block()
         events.single().apply {
             decision.assert().isEqualTo(AuditDecision.IMPLICIT_DENY)
-            matchedPolicyId.assert().isNull()
-            matchedStatementName.assert().isNull()
+            match.assert().isNull()
         }
     }
 
@@ -191,6 +191,7 @@ class AuditingAuthorizationTest {
             every { remoteIp } returns "1.2.3.4"
             every { method } returns "POST"
             every { path } throws IllegalStateException("boom")
+            every { getHeader("User-Agent") } returns "test-agent"
         }
         val events = mutableListOf<AuditEvent>()
         val sink = AuditEventSink(events::add)

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.audit
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.cosec.api.audit.AuditDecision
+import me.ahoo.cosec.api.audit.AuditEvent
+import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.api.authorization.Authorization
+import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.SecurityContext
+import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
+import reactor.kotlin.test.test
+import java.time.Duration
+
+class AuditingAuthorizationTest {
+    private val attributeMap = mutableMapOf<String, Any>()
+    private val request = mockk<Request> {
+        every { appId } returns "app"
+        every { spaceId } returns "0"
+        every { deviceId } returns ""
+        every { requestId } returns "req-1"
+        every { remoteIp } returns "1.2.3.4"
+        every { method } returns "POST"
+        every { path } returns "/api/orders"
+    }
+    private val context = mockk<SecurityContext> {
+        every { tenant.tenantId } returns "t1"
+        every { principal.id } returns "u1"
+        every { principal.authenticated } returns true
+        every { principal.roles } returns emptySet()
+        every { principal.policies } returns emptySet()
+        every { attributes } returns attributeMap
+        every { setAttributeValue(any(), any()) } answers {
+            attributeMap[firstArg()] = secondArg()
+            self as SecurityContext
+        }
+        every { getAttributeValue<Any>(any()) } answers { attributeMap[firstArg()] }
+    }
+
+    private fun authorization(result: Mono<AuthorizeResult>): Pair<Authorization, MutableList<AuditEvent>> {
+        val events = mutableListOf<AuditEvent>()
+        val sink = AuditEventSink(events::add)
+        val delegate = mockk<Authorization> {
+            every { authorize(request, context) } returns result
+        }
+        return AuditingAuthorization(delegate, sink) to events
+    }
+
+    @Test
+    fun publishWhenAllow() {
+        val (authorization, events) = authorization(AuthorizeResult.ALLOW.toMono())
+        authorization.authorize(request, context)
+            .test()
+            .expectNext(AuthorizeResult.ALLOW)
+            .verifyComplete()
+        events.size.assert().isEqualTo(1)
+        events[0].decision.assert().isEqualTo(AuditDecision.ALLOW)
+    }
+
+    @Test
+    fun publishWhenDeny() {
+        val (authorization, events) = authorization(AuthorizeResult.EXPLICIT_DENY.toMono())
+        authorization.authorize(request, context)
+            .test()
+            .expectNext(AuthorizeResult.EXPLICIT_DENY)
+            .verifyComplete()
+        events[0].decision.assert().isEqualTo(AuditDecision.EXPLICIT_DENY)
+    }
+
+    @Test
+    fun publishWhenTooManyRequestsAndErrorPropagates() {
+        val (authorization, events) = authorization(TooManyRequestsException().toMono<AuthorizeResult>())
+        authorization.authorize(request, context)
+            .test()
+            .expectError(TooManyRequestsException::class.java)
+            .verify()
+        events.size.assert().isEqualTo(1)
+        events[0].decision.assert().isEqualTo(AuditDecision.TOO_MANY_REQUESTS)
+    }
+
+    @Test
+    fun publishWhenUnexpectedErrorAndErrorPropagates() {
+        val (authorization, events) = authorization(IllegalStateException().toMono<AuthorizeResult>())
+        authorization.authorize(request, context)
+            .test()
+            .expectError(IllegalStateException::class.java)
+            .verify()
+        events[0].decision.assert().isEqualTo(AuditDecision.ERROR)
+    }
+
+    @Test
+    fun sinkFailureDoesNotAffectAuthorization() {
+        val delegate = mockk<Authorization> {
+            every { authorize(request, context) } returns AuthorizeResult.ALLOW.toMono()
+        }
+        val sink = mockk<AuditEventSink> {
+            every { publish(any()) } throws IllegalStateException("sink down")
+        }
+        val authorization = AuditingAuthorization(delegate, sink)
+        authorization.authorize(request, context)
+            .test()
+            .expectNext(AuthorizeResult.ALLOW)
+            .verifyComplete()
+    }
+
+    @Test
+    fun elapsedNanosMeasuredFromSubscribeToSignal() {
+        val (authorization, events) = authorization(
+            Mono.delay(Duration.ofMillis(50)).map { AuthorizeResult.ALLOW },
+        )
+        authorization.authorize(request, context)
+            .test()
+            .expectNext(AuthorizeResult.ALLOW)
+            .verifyComplete()
+        events[0].elapsedNanos.assert().isGreaterThanOrEqualTo(50_000_000)
+    }
+
+    @Test
+    fun delegateIsWrapped() {
+        val delegate = mockk<Authorization>()
+        val authorization = AuditingAuthorization(delegate, AuditEventSink { })
+        authorization.delegate.assert().isSameAs(delegate)
+    }
+}

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
@@ -122,6 +122,30 @@ class AuditingAuthorizationTest {
     }
 
     @Test
+    fun extractorFailureDoesNotAffectAuthorization() {
+        val throwingRequest = mockk<Request> {
+            every { appId } returns "app"
+            every { spaceId } returns "0"
+            every { deviceId } returns ""
+            every { requestId } returns "req-1"
+            every { remoteIp } returns "1.2.3.4"
+            every { method } returns "POST"
+            every { path } throws IllegalStateException("boom")
+        }
+        val events = mutableListOf<AuditEvent>()
+        val sink = AuditEventSink(events::add)
+        val delegate = mockk<Authorization> {
+            every { authorize(throwingRequest, context) } returns AuthorizeResult.ALLOW.toMono()
+        }
+        val authorization = AuditingAuthorization(delegate, sink)
+        authorization.authorize(throwingRequest, context)
+            .test()
+            .expectNext(AuthorizeResult.ALLOW)
+            .verifyComplete()
+        events.size.assert().isEqualTo(0)
+    }
+
+    @Test
     fun elapsedNanosMeasuredFromSubscribeToSignal() {
         val (authorization, events) = authorization(
             Mono.delay(Duration.ofMillis(50)).map { AuthorizeResult.ALLOW },

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
@@ -22,20 +22,35 @@ import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.api.policy.Effect
 import me.ahoo.cosec.api.policy.Policy
 import me.ahoo.cosec.api.policy.Statement
 import me.ahoo.cosec.api.policy.VerifyResult
+import me.ahoo.cosec.authorization.AppRolePermissionRepository
+import me.ahoo.cosec.authorization.PolicyRepository
 import me.ahoo.cosec.authorization.PolicyVerifyContext
+import me.ahoo.cosec.authorization.SimpleAuthorization
 import me.ahoo.cosec.authorization.VerifyContext.Companion.setVerifyContext
+import me.ahoo.cosec.context.SimpleSecurityContext
+import me.ahoo.cosec.policy.StatementData
+import me.ahoo.cosec.policy.action.AllActionMatcher
+import me.ahoo.cosec.policy.condition.AllConditionMatcher
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import me.ahoo.cosec.principal.SimpleTenantPrincipal
 import me.ahoo.cosec.token.TokenExpiredException
 import me.ahoo.cosec.token.TokenVerificationContexts.setTokenVerificationException
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class AuditingAuthorizationTest {
     private val attributeMap = mutableMapOf<String, Any>()
@@ -118,6 +133,62 @@ class AuditingAuthorizationTest {
             decision.assert().isEqualTo(AuditDecision.IMPLICIT_DENY)
             match.assert().isNull()
         }
+    }
+
+    @Test
+    fun isolateVerifyContextPerConcurrentAuthorization() {
+        val firstPolicy = mockk<Policy> {
+            every { id } returns "first-policy"
+            every { condition } returns AllConditionMatcher.INSTANCE
+            every { statements } returns listOf(
+                StatementData(name = "first-statement", effect = Effect.ALLOW, action = AllActionMatcher.INSTANCE),
+            )
+        }
+        val secondPolicy = mockk<Policy> {
+            every { id } returns "second-policy"
+            every { condition } returns AllConditionMatcher.INSTANCE
+            every { statements } returns listOf(
+                StatementData(name = "second-statement", effect = Effect.ALLOW, action = AllActionMatcher.INSTANCE),
+            )
+        }
+        val policyRepository = mockk<PolicyRepository> {
+            every { getGlobalPolicy() } returnsMany listOf(listOf(firstPolicy).toMono(), listOf(secondPolicy).toMono())
+        }
+        val delegate = SimpleAuthorization(policyRepository, mockk<AppRolePermissionRepository>())
+        val events = CopyOnWriteArrayList<AuditEvent>()
+        val authorization = AuditingAuthorization(delegate, AuditEventSink(events::add))
+        val firstStored = CountDownLatch(1)
+        val secondStored = CountDownLatch(1)
+        val backingAttributes = ConcurrentHashMap<String, Any>()
+        val attributes = object : MutableMap<String, Any> by backingAttributes {
+            override fun put(key: String, value: Any): Any? {
+                val previous = backingAttributes.put(key, value)
+                when ((value as? PolicyVerifyContext)?.policy?.id) {
+                    "first-policy" -> {
+                        firstStored.countDown()
+                        secondStored.await(5, TimeUnit.SECONDS).assert().isTrue()
+                    }
+
+                    "second-policy" -> secondStored.countDown()
+                }
+                return previous
+            }
+        }
+        val sharedContext = SimpleSecurityContext(SimpleTenantPrincipal.ANONYMOUS, attributes = attributes)
+        val firstRequest = requestForPath("/first")
+        val secondRequest = requestForPath("/second")
+
+        val first = authorization.authorize(firstRequest, sharedContext)
+            .subscribeOn(Schedulers.boundedElastic())
+            .toFuture()
+        firstStored.await(5, TimeUnit.SECONDS).assert().isTrue()
+        val second = authorization.authorize(secondRequest, sharedContext)
+            .subscribeOn(Schedulers.boundedElastic())
+            .toFuture()
+        CompletableFuture.allOf(first, second).get(5, TimeUnit.SECONDS)
+
+        events.single { it.path == "/first" }.match?.policyId.assert().isEqualTo("first-policy")
+        events.single { it.path == "/second" }.match?.policyId.assert().isEqualTo("second-policy")
     }
 
     @Test
@@ -223,5 +294,16 @@ class AuditingAuthorizationTest {
         val delegate = mockk<Authorization>()
         val authorization = AuditingAuthorization(delegate, AuditEventSink { })
         authorization.delegate.assert().isSameAs(delegate)
+    }
+
+    private fun requestForPath(path: String) = mockk<Request> {
+        every { appId } returns "app"
+        every { spaceId } returns "0"
+        every { deviceId } returns ""
+        every { requestId } returns path
+        every { remoteIp } returns "1.2.3.4"
+        every { method } returns "GET"
+        every { this@mockk.path } returns path
+        every { getHeader("User-Agent") } returns "test-agent"
     }
 }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
@@ -107,6 +107,20 @@ class AuditingAuthorizationTest {
     }
 
     @Test
+    fun publishWhenDelegateThrowsSynchronously() {
+        val events = mutableListOf<AuditEvent>()
+        val delegate = mockk<Authorization> {
+            every { authorize(request, context) } throws TooManyRequestsException()
+        }
+        val authorization = AuditingAuthorization(delegate, AuditEventSink(events::add))
+        authorization.authorize(request, context)
+            .test()
+            .expectError(TooManyRequestsException::class.java)
+            .verify()
+        events.single().decision.assert().isEqualTo(AuditDecision.TOO_MANY_REQUESTS)
+    }
+
+    @Test
     fun sinkFailureDoesNotAffectAuthorization() {
         val delegate = mockk<Authorization> {
             every { authorize(request, context) } returns AuthorizeResult.ALLOW.toMono()

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
@@ -22,7 +22,14 @@ import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
 import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.Request
+import me.ahoo.cosec.api.policy.Policy
+import me.ahoo.cosec.api.policy.Statement
+import me.ahoo.cosec.api.policy.VerifyResult
+import me.ahoo.cosec.authorization.PolicyVerifyContext
+import me.ahoo.cosec.authorization.VerifyContext.Companion.setVerifyContext
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
+import me.ahoo.cosec.token.TokenExpiredException
+import me.ahoo.cosec.token.TokenVerificationContexts.setTokenVerificationException
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
@@ -83,6 +90,45 @@ class AuditingAuthorizationTest {
             .expectNext(AuthorizeResult.EXPLICIT_DENY)
             .verifyComplete()
         events[0].decision.assert().isEqualTo(AuditDecision.EXPLICIT_DENY)
+    }
+
+    @Test
+    fun publishImplicitDenyWhenDelegateCompletesEmpty() {
+        val (authorization, events) = authorization(Mono.empty())
+        authorization.authorize(request, context)
+            .test()
+            .verifyComplete()
+        events.single().decision.assert().isEqualTo(AuditDecision.IMPLICIT_DENY)
+    }
+
+    @Test
+    fun clearStaleVerifyContextBeforeAuthorization() {
+        context.setVerifyContext(
+            PolicyVerifyContext(
+                policy = mockk<Policy> { every { id } returns "stale-policy" },
+                statementIndex = 0,
+                statement = mockk<Statement> { every { name } returns "stale-statement" },
+                result = VerifyResult.EXPLICIT_DENY,
+            )
+        )
+        val (authorization, events) = authorization(AuthorizeResult.IMPLICIT_DENY.toMono())
+        authorization.authorize(request, context).block()
+        events.single().apply {
+            decision.assert().isEqualTo(AuditDecision.IMPLICIT_DENY)
+            matchedPolicyId.assert().isNull()
+            matchedStatementName.assert().isNull()
+        }
+    }
+
+    @Test
+    fun publishTokenFailureReturnedToClient() {
+        context.setTokenVerificationException(TokenExpiredException())
+        val (authorization, events) = authorization(AuthorizeResult.IMPLICIT_DENY.toMono())
+        authorization.authorize(request, context).block()
+        events.single().apply {
+            decision.assert().isEqualTo(AuditDecision.EXPLICIT_DENY)
+            reason.assert().isEqualTo("Token Expired")
+        }
     }
 
     @Test

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/LoggingAuditEventSinkTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/LoggingAuditEventSinkTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.audit
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import me.ahoo.cosec.api.audit.AuditDecision
+import me.ahoo.cosec.api.audit.AuditEvent
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class LoggingAuditEventSinkTest {
+    private class Recording {
+        val levels = StringBuilder()
+        val json = StringBuilder()
+    }
+
+    private fun event(decision: AuditDecision) = AuditEvent(
+        timestamp = Instant.ofEpochMilli(1),
+        tenantId = "t1",
+        principalId = "u1",
+        authenticated = true,
+        roles = setOf("admin@0"),
+        policies = emptySet(),
+        appId = "app",
+        spaceId = null,
+        deviceId = null,
+        requestId = "req-1",
+        remoteIp = "1.2.3.4",
+        method = "POST",
+        path = "/api/orders",
+        decision = decision,
+        reason = "Explicit Deny",
+        elapsedNanos = 350000,
+        matchedPolicyId = "deny-write",
+        matchedStatementName = "deny-orders-write",
+        matchedRoleId = null,
+        matchedPermissionId = null,
+    )
+
+    private fun loggerFor(recording: Recording): KLogger {
+        val logger = mockk<KLogger>()
+        val slot = slot<() -> Any>()
+        every { logger.debug(capture(slot)) } answers {
+            recording.levels.append("debug")
+            recording.json.append(slot.captured())
+            Unit
+        }
+        every { logger.warn(capture(slot)) } answers {
+            recording.levels.append("warn")
+            recording.json.append(slot.captured())
+            Unit
+        }
+        every { logger.error(capture(slot)) } answers {
+            recording.levels.append("error")
+            recording.json.append(slot.captured())
+            Unit
+        }
+        return logger
+    }
+
+    private fun publish(decision: AuditDecision): Recording {
+        val recording = Recording()
+        val sink = LoggingAuditEventSink(loggerFor(recording))
+        sink.publish(event(decision))
+        return recording
+    }
+
+    @Test
+    fun allowLogsAtDebug() {
+        val recording = publish(AuditDecision.ALLOW)
+        recording.levels.toString().assert().isEqualTo("debug")
+        recording.json.toString().assert().contains("\"decision\":\"ALLOW\"")
+    }
+
+    @Test
+    fun explicitDenyLogsAtWarn() {
+        val recording = publish(AuditDecision.EXPLICIT_DENY)
+        recording.levels.toString().assert().isEqualTo("warn")
+        val json = recording.json.toString()
+        json.assert().contains("\"decision\":\"EXPLICIT_DENY\"")
+        json.assert().contains("\"matchedPolicyId\":\"deny-write\"")
+        json.assert().contains("\"elapsedNanos\":350000")
+    }
+
+    @Test
+    fun implicitDenyLogsAtWarn() {
+        val recording = publish(AuditDecision.IMPLICIT_DENY)
+        recording.levels.toString().assert().isEqualTo("warn")
+        recording.json.toString().assert().contains("\"decision\":\"IMPLICIT_DENY\"")
+    }
+
+    @Test
+    fun tooManyRequestsLogsAtWarn() {
+        val recording = publish(AuditDecision.TOO_MANY_REQUESTS)
+        recording.levels.toString().assert().isEqualTo("warn")
+        recording.json.toString().assert().contains("\"decision\":\"TOO_MANY_REQUESTS\"")
+    }
+
+    @Test
+    fun errorLogsAtError() {
+        val recording = publish(AuditDecision.ERROR)
+        recording.levels.toString().assert().isEqualTo("error")
+        recording.json.toString().assert().contains("\"decision\":\"ERROR\"")
+    }
+
+    @Test
+    fun defaultLoggerName() {
+        LoggingAuditEventSink.LOGGER_NAME.assert().isEqualTo("me.ahoo.cosec.audit")
+    }
+}

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/LoggingAuditEventSinkTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/LoggingAuditEventSinkTest.kt
@@ -18,7 +18,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import me.ahoo.cosec.api.audit.AuditDecision
+import me.ahoo.cosec.api.audit.AuditDevice
 import me.ahoo.cosec.api.audit.AuditEvent
+import me.ahoo.cosec.api.audit.AuditMatch
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -38,7 +40,7 @@ class LoggingAuditEventSinkTest {
         policies = emptySet(),
         appId = "app",
         spaceId = null,
-        deviceId = null,
+        device = AuditDevice(id = "device-1", userAgent = "test-agent"),
         requestId = "req-1",
         remoteIp = "1.2.3.4",
         method = "POST",
@@ -46,10 +48,7 @@ class LoggingAuditEventSinkTest {
         decision = decision,
         reason = "Explicit Deny",
         elapsedNanos = 350000,
-        matchedPolicyId = "deny-write",
-        matchedStatementName = "deny-orders-write",
-        matchedRoleId = null,
-        matchedPermissionId = null,
+        match = AuditMatch(policyId = "deny-write", statementName = "deny-orders-write"),
     )
 
     private fun loggerFor(recording: Recording): KLogger {
@@ -93,7 +92,8 @@ class LoggingAuditEventSinkTest {
         recording.levels.toString().assert().isEqualTo("warn")
         val json = recording.json.toString()
         json.assert().contains("\"decision\":\"EXPLICIT_DENY\"")
-        json.assert().contains("\"matchedPolicyId\":\"deny-write\"")
+        json.assert().contains("\"device\":{\"id\":\"device-1\",\"userAgent\":\"test-agent\"}")
+        json.assert().contains("\"match\":{\"policyId\":\"deny-write\",\"statementName\":\"deny-orders-write\"")
         json.assert().contains("\"elapsedNanos\":350000")
     }
 

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.audit
+
+import me.ahoo.cosec.spring.boot.starter.ENABLED_SUFFIX_KEY
+import me.ahoo.cosec.spring.boot.starter.EnabledCapable
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+/**
+ * CoSec Audit Properties.
+ *
+ * @author ahoo wang
+ */
+@ConfigurationProperties(AuditProperties.PREFIX)
+data class AuditProperties(
+    @DefaultValue("true") override var enabled: Boolean = true,
+) : EnabledCapable {
+    companion object {
+        const val PREFIX: String = "cosec.audit"
+        const val ENABLED_KEY: String = PREFIX + ENABLED_SUFFIX_KEY
+    }
+}

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
@@ -22,12 +22,9 @@ import me.ahoo.cosec.spring.boot.starter.authorization.CoSecAuthorizationAutoCon
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Primary
 
 /**
  * CoSec Audit AutoConfiguration.
@@ -47,9 +44,7 @@ class CoSecAuditAutoConfiguration {
     }
 
     @Bean(AUDITING_AUTHORIZATION_BEAN_NAME)
-    @Primary
     @ConditionalOnBean(name = [CoSecAuthorizationAutoConfiguration.BEAN_NAME])
-    @ConditionalOnMissingClass(OPENTELEMETRY_INSTRUMENTER_CLASS)
     fun cosecAuditingAuthorization(
         @Qualifier(CoSecAuthorizationAutoConfiguration.BEAN_NAME) authorization: Authorization,
         auditEventSink: AuditEventSink,
@@ -57,24 +52,7 @@ class CoSecAuditAutoConfiguration {
         return AuditingAuthorization(authorization, auditEventSink)
     }
 
-    @Bean(AUDITING_AUTHORIZATION_INNER_BEAN_NAME)
-    @ConditionalOnBean(name = [CoSecAuthorizationAutoConfiguration.BEAN_NAME])
-    @ConditionalOnClass(
-        name = [
-            OPENTELEMETRY_INSTRUMENTER_CLASS,
-            "io.opentelemetry.api.trace.Span",
-        ],
-    )
-    fun cosecAuditingAuthorizationInner(
-        @Qualifier(CoSecAuthorizationAutoConfiguration.BEAN_NAME) authorization: Authorization,
-        auditEventSink: AuditEventSink,
-    ): AuditingAuthorization {
-        return AuditingAuthorization(authorization, auditEventSink)
-    }
-
     companion object {
-        const val AUDITING_AUTHORIZATION_INNER_BEAN_NAME = "cosecAuditingAuthorizationInner"
         const val AUDITING_AUTHORIZATION_BEAN_NAME = "cosecAuditingAuthorization"
-        private const val OPENTELEMETRY_INSTRUMENTER_CLASS = "me.ahoo.cosec.opentelemetry.CoSecInstrumenter"
     }
 }

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.audit
+
+import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.api.authorization.Authorization
+import me.ahoo.cosec.audit.AuditingAuthorization
+import me.ahoo.cosec.audit.LoggingAuditEventSink
+import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
+import me.ahoo.cosec.spring.boot.starter.authorization.CoSecAuthorizationAutoConfiguration
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+/**
+ * CoSec Audit AutoConfiguration.
+ *
+ * @author ahoo wang
+ */
+@AutoConfiguration(after = [CoSecAuthorizationAutoConfiguration::class])
+@ConditionalOnCoSecEnabled
+@ConditionalOnAuditEnabled
+@EnableConfigurationProperties(AuditProperties::class)
+class CoSecAuditAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(AuditEventSink::class)
+    fun auditEventSink(): AuditEventSink {
+        return LoggingAuditEventSink()
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(name = [CoSecAuthorizationAutoConfiguration.BEAN_NAME])
+    @ConditionalOnMissingClass(OPENTELEMETRY_INSTRUMENTER_CLASS)
+    fun cosecAuditingAuthorization(
+        @Qualifier(CoSecAuthorizationAutoConfiguration.BEAN_NAME) authorization: Authorization,
+        auditEventSink: AuditEventSink,
+    ): AuditingAuthorization {
+        return AuditingAuthorization(authorization, auditEventSink)
+    }
+
+    @Bean(AUDITING_AUTHORIZATION_INNER_BEAN_NAME)
+    @ConditionalOnBean(name = [CoSecAuthorizationAutoConfiguration.BEAN_NAME])
+    @ConditionalOnClass(
+        name = [
+            OPENTELEMETRY_INSTRUMENTER_CLASS,
+            "io.opentelemetry.api.trace.Span",
+        ],
+    )
+    fun cosecAuditingAuthorizationInner(
+        @Qualifier(CoSecAuthorizationAutoConfiguration.BEAN_NAME) authorization: Authorization,
+        auditEventSink: AuditEventSink,
+    ): AuditingAuthorization {
+        return AuditingAuthorization(authorization, auditEventSink)
+    }
+
+    companion object {
+        const val AUDITING_AUTHORIZATION_INNER_BEAN_NAME = "cosecAuditingAuthorizationInner"
+        const val AUDITING_AUTHORIZATION_BEAN_NAME = "cosecAuditingAuthorization"
+        private const val OPENTELEMETRY_INSTRUMENTER_CLASS = "me.ahoo.cosec.opentelemetry.CoSecInstrumenter"
+    }
+}

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
@@ -44,7 +44,10 @@ class CoSecAuditAutoConfiguration {
     }
 
     @Bean(AUDITING_AUTHORIZATION_BEAN_NAME)
-    @ConditionalOnBean(name = [CoSecAuthorizationAutoConfiguration.BEAN_NAME])
+    @ConditionalOnBean(
+        name = [CoSecAuthorizationAutoConfiguration.BEAN_NAME],
+        annotation = [CoSecAuthorizationAutoConfiguration.AutoConfigured::class],
+    )
     fun cosecAuditingAuthorization(
         @Qualifier(CoSecAuthorizationAutoConfiguration.BEAN_NAME) authorization: Authorization,
         auditEventSink: AuditEventSink,

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
@@ -46,7 +46,7 @@ class CoSecAuditAutoConfiguration {
         return LoggingAuditEventSink()
     }
 
-    @Bean
+    @Bean(AUDITING_AUTHORIZATION_BEAN_NAME)
     @Primary
     @ConditionalOnBean(name = [CoSecAuthorizationAutoConfiguration.BEAN_NAME])
     @ConditionalOnMissingClass(OPENTELEMETRY_INSTRUMENTER_CLASS)

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditFallbackAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditFallbackAutoConfiguration.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.audit
+
+import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
+import me.ahoo.cosec.spring.boot.starter.opentelemetry.CoSecOpenTelemetryAutoConfiguration
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+
+@AutoConfiguration(
+    after = [CoSecAuditAutoConfiguration::class],
+    afterName = ["me.ahoo.cosec.spring.boot.starter.opentelemetry.CoSecOpenTelemetryAutoConfiguration"],
+)
+@ConditionalOnCoSecEnabled
+@ConditionalOnAuditEnabled
+@ConditionalOnBean(name = [CoSecAuditAutoConfiguration.AUDITING_AUTHORIZATION_BEAN_NAME])
+@ConditionalOnMissingBean(
+    name = [
+        CoSecOpenTelemetryAutoConfiguration.TRACING_AUTHORIZATION_BEAN_NAME,
+        CoSecOpenTelemetryAutoConfiguration.AUDITED_TRACING_AUTHORIZATION_BEAN_NAME,
+    ],
+)
+class CoSecAuditFallbackAutoConfiguration : BeanFactoryPostProcessor {
+    override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
+        beanFactory.getBeanDefinition(
+            CoSecAuditAutoConfiguration.AUDITING_AUTHORIZATION_BEAN_NAME
+        ).isPrimary = true
+    }
+}

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/ConditionalOnAuditEnabled.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/ConditionalOnAuditEnabled.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.audit
+
+import me.ahoo.cosec.spring.boot.starter.ENABLED_SUFFIX_KEY
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/**
+ * Conditional On CoSec Audit Enabled.
+ *
+ * @author ahoo wang
+ */
+@ConditionalOnProperty(
+    value = [ConditionalOnAuditEnabled.ENABLED_KEY],
+    matchIfMissing = true,
+    havingValue = "true",
+)
+annotation class ConditionalOnAuditEnabled {
+    companion object {
+        const val ENABLED_KEY = AuditProperties.PREFIX + ENABLED_SUFFIX_KEY
+    }
+}

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecAuthorizationAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecAuthorizationAutoConfiguration.kt
@@ -136,4 +136,8 @@ class CoSecAuthorizationAutoConfiguration {
             return ReactiveAuthorizationFilter(securityContextParser, requestParser, authorization)
         }
     }
+
+    companion object {
+        const val BEAN_NAME = "cosecAuthorization"
+    }
 }

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecAuthorizationAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/CoSecAuthorizationAutoConfiguration.kt
@@ -52,6 +52,10 @@ import org.springframework.web.server.ServerWebExchange
     AuthorizationProperties::class,
 )
 class CoSecAuthorizationAutoConfiguration {
+    @Target(AnnotationTarget.FUNCTION)
+    @Retention(AnnotationRetention.RUNTIME)
+    internal annotation class AutoConfigured
+
     @Bean
     @ConditionalOnMissingBean
     fun securityContextParser(tokenVerifier: TokenVerifier): SecurityContextParser {
@@ -93,6 +97,7 @@ class CoSecAuthorizationAutoConfiguration {
     }
 
     @Bean
+    @AutoConfigured
     @ConditionalOnMissingBean
     fun cosecAuthorization(
         policyRepository: PolicyRepository,

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/opentelemetry/CoSecOpenTelemetryAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/opentelemetry/CoSecOpenTelemetryAutoConfiguration.kt
@@ -14,20 +14,37 @@
 package me.ahoo.cosec.spring.boot.starter.opentelemetry
 
 import me.ahoo.cosec.api.authorization.Authorization
+import me.ahoo.cosec.audit.AuditingAuthorization
 import me.ahoo.cosec.opentelemetry.TracingAuthorization
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
+import me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 
-@AutoConfiguration
+@AutoConfiguration(after = [CoSecAuditAutoConfiguration::class])
 @ConditionalOnCoSecEnabled
 @ConditionalOnOpenTelemetryEnabled
 class CoSecOpenTelemetryAutoConfiguration {
 
     @Bean
     @Primary
+    @ConditionalOnMissingBean(AuditingAuthorization::class)
     fun tracingAuthorization(authorization: Authorization): Authorization {
         return TracingAuthorization(authorization)
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(AuditingAuthorization::class)
+    fun auditedTracingAuthorization(
+        @Qualifier(
+            CoSecAuditAutoConfiguration.AUDITING_AUTHORIZATION_INNER_BEAN_NAME
+        ) auditingAuthorization: Authorization,
+    ): Authorization {
+        return TracingAuthorization(auditingAuthorization)
     }
 }

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/opentelemetry/CoSecOpenTelemetryAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/opentelemetry/CoSecOpenTelemetryAutoConfiguration.kt
@@ -36,7 +36,7 @@ class CoSecOpenTelemetryAutoConfiguration {
         return TracingAuthorization(authorization)
     }
 
-    @Bean(AUDITED_TRACING_AUTHORIZATION_BEAN_NAME)
+    @Bean(name = [AUDITED_TRACING_AUTHORIZATION_BEAN_NAME, TRACING_AUTHORIZATION_BEAN_NAME])
     @Primary
     @ConditionalOnBean(name = [CoSecAuditAutoConfiguration.AUDITING_AUTHORIZATION_BEAN_NAME])
     fun auditedTracingAuthorization(

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/opentelemetry/CoSecOpenTelemetryAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/opentelemetry/CoSecOpenTelemetryAutoConfiguration.kt
@@ -14,7 +14,6 @@
 package me.ahoo.cosec.spring.boot.starter.opentelemetry
 
 import me.ahoo.cosec.api.authorization.Authorization
-import me.ahoo.cosec.audit.AuditingAuthorization
 import me.ahoo.cosec.opentelemetry.TracingAuthorization
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
 import me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration
@@ -30,21 +29,26 @@ import org.springframework.context.annotation.Primary
 @ConditionalOnOpenTelemetryEnabled
 class CoSecOpenTelemetryAutoConfiguration {
 
-    @Bean
+    @Bean(TRACING_AUTHORIZATION_BEAN_NAME)
     @Primary
-    @ConditionalOnMissingBean(AuditingAuthorization::class)
+    @ConditionalOnMissingBean(name = [CoSecAuditAutoConfiguration.AUDITING_AUTHORIZATION_BEAN_NAME])
     fun tracingAuthorization(authorization: Authorization): Authorization {
         return TracingAuthorization(authorization)
     }
 
-    @Bean
+    @Bean(AUDITED_TRACING_AUTHORIZATION_BEAN_NAME)
     @Primary
-    @ConditionalOnBean(AuditingAuthorization::class)
+    @ConditionalOnBean(name = [CoSecAuditAutoConfiguration.AUDITING_AUTHORIZATION_BEAN_NAME])
     fun auditedTracingAuthorization(
         @Qualifier(
-            CoSecAuditAutoConfiguration.AUDITING_AUTHORIZATION_INNER_BEAN_NAME
+            CoSecAuditAutoConfiguration.AUDITING_AUTHORIZATION_BEAN_NAME
         ) auditingAuthorization: Authorization,
     ): Authorization {
         return TracingAuthorization(auditingAuthorization)
+    }
+
+    companion object {
+        const val TRACING_AUTHORIZATION_BEAN_NAME = "tracingAuthorization"
+        const val AUDITED_TRACING_AUTHORIZATION_BEAN_NAME = "auditedTracingAuthorization"
     }
 }

--- a/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,4 @@ me.ahoo.cosec.spring.boot.starter.ip2region.Ip2RegionAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.actuate.CoSecEndpointAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.openapi.CoSecOpenAPIAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.authorization.limiter.CoSecRedisRateLimiterAutoConfiguration
+me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration

--- a/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -15,3 +15,4 @@ me.ahoo.cosec.spring.boot.starter.actuate.CoSecEndpointAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.openapi.CoSecOpenAPIAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.authorization.limiter.CoSecRedisRateLimiterAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration
+me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditFallbackAutoConfiguration

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.audit
+
+import io.mockk.mockk
+import me.ahoo.cosec.api.authorization.Authorization
+import me.ahoo.cosec.audit.AuditingAuthorization
+import me.ahoo.cosec.opentelemetry.TracingAuthorization
+import me.ahoo.cosec.spring.boot.starter.authorization.CoSecAuthorizationAutoConfiguration
+import me.ahoo.cosec.spring.boot.starter.opentelemetry.CoSecOpenTelemetryAutoConfiguration
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.util.function.Supplier
+
+class AuditOpenTelemetryCompositionTest {
+    private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun auditOnAndOtelOnTracingWrapsAuditing() {
+        contextRunner
+            .withBean(
+                CoSecAuthorizationAutoConfiguration.BEAN_NAME,
+                Authorization::class.java,
+                Supplier { mockk() },
+            )
+            .withUserConfiguration(
+                CoSecAuditAutoConfiguration::class.java,
+                CoSecOpenTelemetryAutoConfiguration::class.java
+            )
+            .run { context: AssertableApplicationContext ->
+                assertThat(context).hasSingleBean(AuditingAuthorization::class.java)
+                assertThat(context).hasSingleBean(TracingAuthorization::class.java)
+                val authorization = context.getBean(Authorization::class.java)
+                assertThat(authorization).isInstanceOf(TracingAuthorization::class.java)
+                val tracing = authorization as TracingAuthorization
+                assertThat(tracing.delegate).isInstanceOf(AuditingAuthorization::class.java)
+                val auditing = tracing.delegate as AuditingAuthorization
+                assertThat(
+                    auditing.delegate
+                ).isSameAs(context.getBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java))
+            }
+    }
+
+    @Test
+    fun auditOffAndOtelOnKeepsCurrentBehavior() {
+        contextRunner
+            .withPropertyValues("cosec.audit.enabled=false")
+            .withBean(
+                CoSecAuthorizationAutoConfiguration.BEAN_NAME,
+                Authorization::class.java,
+                Supplier { mockk() },
+            )
+            .withUserConfiguration(
+                CoSecAuditAutoConfiguration::class.java,
+                CoSecOpenTelemetryAutoConfiguration::class.java
+            )
+            .run { context: AssertableApplicationContext ->
+                assertThat(context).doesNotHaveBean(AuditingAuthorization::class.java)
+                assertThat(context).hasSingleBean(TracingAuthorization::class.java)
+                assertThat(context.getBean(Authorization::class.java)).isInstanceOf(TracingAuthorization::class.java)
+            }
+    }
+
+    @Test
+    fun auditOnAndOtelOffAuditingIsPrimary() {
+        contextRunner
+            .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
+            .withBean(
+                CoSecAuthorizationAutoConfiguration.BEAN_NAME,
+                Authorization::class.java,
+                Supplier { mockk() },
+            )
+            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                assertThat(context.getBean(Authorization::class.java)).isInstanceOf(AuditingAuthorization::class.java)
+            }
+    }
+}

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
@@ -20,7 +20,7 @@ import me.ahoo.cosec.audit.AuditingAuthorization
 import me.ahoo.cosec.opentelemetry.TracingAuthorization
 import me.ahoo.cosec.spring.boot.starter.authorization.CoSecAuthorizationAutoConfiguration
 import me.ahoo.cosec.spring.boot.starter.opentelemetry.CoSecOpenTelemetryAutoConfiguration
-import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
@@ -44,22 +44,20 @@ class AuditOpenTelemetryCompositionTest {
                 CoSecAuditFallbackAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
-                assertThat(context).hasSingleBean(AuditingAuthorization::class.java)
-                assertThat(context).hasSingleBean(TracingAuthorization::class.java)
+                context.getBeansOfType(AuditingAuthorization::class.java).assert().hasSize(1)
+                context.getBeansOfType(TracingAuthorization::class.java).assert().hasSize(1)
                 val authorization = context.getBean(Authorization::class.java)
-                assertThat(authorization).isInstanceOf(TracingAuthorization::class.java)
-                assertThat(
-                    context.getBean(
-                        CoSecOpenTelemetryAutoConfiguration.TRACING_AUTHORIZATION_BEAN_NAME,
-                        Authorization::class.java,
-                    )
-                ).isSameAs(authorization)
+                authorization.assert().isInstanceOf(TracingAuthorization::class.java)
+                context.getBean(
+                    CoSecOpenTelemetryAutoConfiguration.TRACING_AUTHORIZATION_BEAN_NAME,
+                    Authorization::class.java,
+                ).assert().isSameAs(authorization)
                 val tracing = authorization as TracingAuthorization
-                assertThat(tracing.delegate).isInstanceOf(AuditingAuthorization::class.java)
+                tracing.delegate.assert().isInstanceOf(AuditingAuthorization::class.java)
                 val auditing = tracing.delegate as AuditingAuthorization
-                assertThat(
-                    auditing.delegate
-                ).isSameAs(context.getBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java))
+                auditing.delegate.assert().isSameAs(
+                    context.getBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java)
+                )
             }
     }
 
@@ -78,9 +76,9 @@ class AuditOpenTelemetryCompositionTest {
                 CoSecAuditFallbackAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
-                assertThat(context).doesNotHaveBean(AuditingAuthorization::class.java)
-                assertThat(context).hasSingleBean(TracingAuthorization::class.java)
-                assertThat(context.getBean(Authorization::class.java)).isInstanceOf(TracingAuthorization::class.java)
+                context.getBeansOfType(AuditingAuthorization::class.java).assert().isEmpty()
+                context.getBeansOfType(TracingAuthorization::class.java).assert().hasSize(1)
+                context.getBean(Authorization::class.java).assert().isInstanceOf(TracingAuthorization::class.java)
             }
     }
 
@@ -98,7 +96,7 @@ class AuditOpenTelemetryCompositionTest {
                 CoSecAuditFallbackAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
-                assertThat(context.getBean(Authorization::class.java)).isInstanceOf(AuditingAuthorization::class.java)
+                context.getBean(Authorization::class.java).assert().isInstanceOf(AuditingAuthorization::class.java)
             }
     }
 
@@ -118,8 +116,8 @@ class AuditOpenTelemetryCompositionTest {
             )
             .run { context: AssertableApplicationContext ->
                 val authorization = context.getBean(Authorization::class.java)
-                assertThat(authorization).isInstanceOf(TracingAuthorization::class.java)
-                assertThat((authorization as TracingAuthorization).delegate).isSameAs(customAuthorization)
+                authorization.assert().isInstanceOf(TracingAuthorization::class.java)
+                (authorization as TracingAuthorization).delegate.assert().isSameAs(customAuthorization)
             }
     }
 }

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
@@ -14,6 +14,7 @@
 package me.ahoo.cosec.spring.boot.starter.audit
 
 import io.mockk.mockk
+import me.ahoo.cosec.api.audit.AuditEventSink
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.audit.AuditingAuthorization
 import me.ahoo.cosec.opentelemetry.TracingAuthorization
@@ -39,7 +40,8 @@ class AuditOpenTelemetryCompositionTest {
             )
             .withUserConfiguration(
                 CoSecAuditAutoConfiguration::class.java,
-                CoSecOpenTelemetryAutoConfiguration::class.java
+                CoSecOpenTelemetryAutoConfiguration::class.java,
+                CoSecAuditFallbackAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
                 assertThat(context).hasSingleBean(AuditingAuthorization::class.java)
@@ -66,7 +68,8 @@ class AuditOpenTelemetryCompositionTest {
             )
             .withUserConfiguration(
                 CoSecAuditAutoConfiguration::class.java,
-                CoSecOpenTelemetryAutoConfiguration::class.java
+                CoSecOpenTelemetryAutoConfiguration::class.java,
+                CoSecAuditFallbackAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
                 assertThat(context).doesNotHaveBean(AuditingAuthorization::class.java)
@@ -84,9 +87,33 @@ class AuditOpenTelemetryCompositionTest {
                 Authorization::class.java,
                 Supplier { mockk() },
             )
-            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .withUserConfiguration(
+                CoSecAuditAutoConfiguration::class.java,
+                CoSecAuditFallbackAutoConfiguration::class.java,
+            )
             .run { context: AssertableApplicationContext ->
                 assertThat(context.getBean(Authorization::class.java)).isInstanceOf(AuditingAuthorization::class.java)
+            }
+    }
+
+    @Test
+    fun customAuditingAuthorizationIsTracedWithoutInternalBeanName() {
+        val customAuthorization = AuditingAuthorization(mockk(), AuditEventSink { })
+        contextRunner
+            .withBean(
+                "customAuthorization",
+                AuditingAuthorization::class.java,
+                Supplier { customAuthorization },
+            )
+            .withUserConfiguration(
+                CoSecAuditAutoConfiguration::class.java,
+                CoSecOpenTelemetryAutoConfiguration::class.java,
+                CoSecAuditFallbackAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                val authorization = context.getBean(Authorization::class.java)
+                assertThat(authorization).isInstanceOf(TracingAuthorization::class.java)
+                assertThat((authorization as TracingAuthorization).delegate).isSameAs(customAuthorization)
             }
     }
 }

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
@@ -48,6 +48,12 @@ class AuditOpenTelemetryCompositionTest {
                 assertThat(context).hasSingleBean(TracingAuthorization::class.java)
                 val authorization = context.getBean(Authorization::class.java)
                 assertThat(authorization).isInstanceOf(TracingAuthorization::class.java)
+                assertThat(
+                    context.getBean(
+                        CoSecOpenTelemetryAutoConfiguration.TRACING_AUTHORIZATION_BEAN_NAME,
+                        Authorization::class.java,
+                    )
+                ).isSameAs(authorization)
                 val tracing = authorization as TracingAuthorization
                 assertThat(tracing.delegate).isInstanceOf(AuditingAuthorization::class.java)
                 val auditing = tracing.delegate as AuditingAuthorization

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditOpenTelemetryCompositionTest.kt
@@ -33,12 +33,8 @@ class AuditOpenTelemetryCompositionTest {
     @Test
     fun auditOnAndOtelOnTracingWrapsAuditing() {
         contextRunner
-            .withBean(
-                CoSecAuthorizationAutoConfiguration.BEAN_NAME,
-                Authorization::class.java,
-                Supplier { mockk() },
-            )
             .withUserConfiguration(
+                AutoConfiguredAuthorizationTestConfiguration::class.java,
                 CoSecAuditAutoConfiguration::class.java,
                 CoSecOpenTelemetryAutoConfiguration::class.java,
                 CoSecAuditFallbackAutoConfiguration::class.java,
@@ -65,12 +61,8 @@ class AuditOpenTelemetryCompositionTest {
     fun auditOffAndOtelOnKeepsCurrentBehavior() {
         contextRunner
             .withPropertyValues("cosec.audit.enabled=false")
-            .withBean(
-                CoSecAuthorizationAutoConfiguration.BEAN_NAME,
-                Authorization::class.java,
-                Supplier { mockk() },
-            )
             .withUserConfiguration(
+                AutoConfiguredAuthorizationTestConfiguration::class.java,
                 CoSecAuditAutoConfiguration::class.java,
                 CoSecOpenTelemetryAutoConfiguration::class.java,
                 CoSecAuditFallbackAutoConfiguration::class.java,
@@ -86,12 +78,8 @@ class AuditOpenTelemetryCompositionTest {
     fun auditOnAndOtelOffAuditingIsPrimary() {
         contextRunner
             .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
-            .withBean(
-                CoSecAuthorizationAutoConfiguration.BEAN_NAME,
-                Authorization::class.java,
-                Supplier { mockk() },
-            )
             .withUserConfiguration(
+                AutoConfiguredAuthorizationTestConfiguration::class.java,
                 CoSecAuditAutoConfiguration::class.java,
                 CoSecAuditFallbackAutoConfiguration::class.java,
             )

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfigurationTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.audit
+
+import io.mockk.mockk
+import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.api.authorization.Authorization
+import me.ahoo.cosec.audit.AuditingAuthorization
+import me.ahoo.cosec.audit.LoggingAuditEventSink
+import me.ahoo.cosec.spring.boot.starter.authorization.CoSecAuthorizationAutoConfiguration
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.util.function.Supplier
+
+class CoSecAuditAutoConfigurationTest {
+    private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun auditOnWhenOpenTelemetryAbsent() {
+        contextRunner
+            .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
+            .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
+            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                assertThat(context).hasSingleBean(AuditingAuthorization::class.java)
+                assertThat(context).hasSingleBean(LoggingAuditEventSink::class.java)
+                val authorization = context.getBean(Authorization::class.java)
+                assertThat(authorization).isInstanceOf(AuditingAuthorization::class.java)
+            }
+    }
+
+    @Test
+    fun auditOffLoadsNothing() {
+        contextRunner
+            .withPropertyValues("cosec.audit.enabled=false")
+            .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
+            .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
+            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                assertThat(context).doesNotHaveBean(AuditingAuthorization::class.java)
+                assertThat(context).doesNotHaveBean(AuditEventSink::class.java)
+            }
+    }
+
+    @Test
+    fun customSinkWins() {
+        contextRunner
+            .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
+            .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
+            .withBean("customSink", AuditEventSink::class.java, Supplier { mockk() })
+            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                val sink = context.getBean(AuditEventSink::class.java)
+                assertThat(sink).isNotInstanceOf(LoggingAuditEventSink::class.java)
+            }
+    }
+
+    @Test
+    fun skippedWhenAuthorizationBeanReplacedByUser() {
+        contextRunner
+            .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
+            .withBean("customAuthorization", Authorization::class.java, Supplier { mockk() })
+            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                assertThat(context).doesNotHaveBean(AuditingAuthorization::class.java)
+            }
+    }
+}

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfigurationTest.kt
@@ -19,7 +19,7 @@ import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.audit.AuditingAuthorization
 import me.ahoo.cosec.audit.LoggingAuditEventSink
 import me.ahoo.cosec.spring.boot.starter.authorization.CoSecAuthorizationAutoConfiguration
-import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
@@ -39,10 +39,10 @@ class CoSecAuditAutoConfigurationTest {
                 CoSecAuditFallbackAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
-                assertThat(context).hasSingleBean(AuditingAuthorization::class.java)
-                assertThat(context).hasSingleBean(LoggingAuditEventSink::class.java)
+                context.getBeansOfType(AuditingAuthorization::class.java).assert().hasSize(1)
+                context.getBeansOfType(LoggingAuditEventSink::class.java).assert().hasSize(1)
                 val authorization = context.getBean(Authorization::class.java)
-                assertThat(authorization).isInstanceOf(AuditingAuthorization::class.java)
+                authorization.assert().isInstanceOf(AuditingAuthorization::class.java)
             }
     }
 
@@ -54,8 +54,8 @@ class CoSecAuditAutoConfigurationTest {
             .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
             .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
             .run { context: AssertableApplicationContext ->
-                assertThat(context).doesNotHaveBean(AuditingAuthorization::class.java)
-                assertThat(context).doesNotHaveBean(AuditEventSink::class.java)
+                context.getBeansOfType(AuditingAuthorization::class.java).assert().isEmpty()
+                context.getBeansOfType(AuditEventSink::class.java).assert().isEmpty()
             }
     }
 
@@ -68,7 +68,7 @@ class CoSecAuditAutoConfigurationTest {
             .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
             .run { context: AssertableApplicationContext ->
                 val sink = context.getBean(AuditEventSink::class.java)
-                assertThat(sink).isNotInstanceOf(LoggingAuditEventSink::class.java)
+                (sink is LoggingAuditEventSink).assert().isFalse()
             }
     }
 
@@ -79,7 +79,7 @@ class CoSecAuditAutoConfigurationTest {
             .withBean("customAuthorization", Authorization::class.java, Supplier { mockk() })
             .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
             .run { context: AssertableApplicationContext ->
-                assertThat(context).doesNotHaveBean(AuditingAuthorization::class.java)
+                context.getBeansOfType(AuditingAuthorization::class.java).assert().isEmpty()
             }
     }
 
@@ -92,8 +92,8 @@ class CoSecAuditAutoConfigurationTest {
                 CoSecAuditFallbackAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
-                assertThat(context).hasSingleBean(AuditingAuthorization::class.java)
-                assertThat(context.getBean(Authorization::class.java)).isInstanceOf(AuditingAuthorization::class.java)
+                context.getBeansOfType(AuditingAuthorization::class.java).assert().hasSize(1)
+                context.getBean(Authorization::class.java).assert().isInstanceOf(AuditingAuthorization::class.java)
             }
     }
 }

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfigurationTest.kt
@@ -24,7 +24,16 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import java.util.function.Supplier
+
+@Configuration(proxyBeanMethods = false)
+class AutoConfiguredAuthorizationTestConfiguration {
+    @Bean(CoSecAuthorizationAutoConfiguration.BEAN_NAME)
+    @CoSecAuthorizationAutoConfiguration.AutoConfigured
+    fun cosecAuthorization(): Authorization = mockk()
+}
 
 class CoSecAuditAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
@@ -33,8 +42,8 @@ class CoSecAuditAutoConfigurationTest {
     fun auditOnWhenOpenTelemetryAbsent() {
         contextRunner
             .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
-            .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
             .withUserConfiguration(
+                AutoConfiguredAuthorizationTestConfiguration::class.java,
                 CoSecAuditAutoConfiguration::class.java,
                 CoSecAuditFallbackAutoConfiguration::class.java,
             )
@@ -51,8 +60,10 @@ class CoSecAuditAutoConfigurationTest {
         contextRunner
             .withPropertyValues("cosec.audit.enabled=false")
             .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
-            .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
-            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .withUserConfiguration(
+                AutoConfiguredAuthorizationTestConfiguration::class.java,
+                CoSecAuditAutoConfiguration::class.java,
+            )
             .run { context: AssertableApplicationContext ->
                 context.getBeansOfType(AuditingAuthorization::class.java).assert().isEmpty()
                 context.getBeansOfType(AuditEventSink::class.java).assert().isEmpty()
@@ -63,9 +74,11 @@ class CoSecAuditAutoConfigurationTest {
     fun customSinkWins() {
         contextRunner
             .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
-            .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
             .withBean("customSink", AuditEventSink::class.java, Supplier { mockk() })
-            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .withUserConfiguration(
+                AutoConfiguredAuthorizationTestConfiguration::class.java,
+                CoSecAuditAutoConfiguration::class.java,
+            )
             .run { context: AssertableApplicationContext ->
                 val sink = context.getBean(AuditEventSink::class.java)
                 (sink is LoggingAuditEventSink).assert().isFalse()
@@ -84,10 +97,31 @@ class CoSecAuditAutoConfigurationTest {
     }
 
     @Test
+    fun skippedWhenPrimaryAuthorizationUsesAutoConfiguredBeanName() {
+        val customAuthorization = mockk<Authorization>()
+        contextRunner
+            .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
+            .withBean(
+                CoSecAuthorizationAutoConfiguration.BEAN_NAME,
+                Authorization::class.java,
+                Supplier { customAuthorization },
+                { it.isPrimary = true },
+            )
+            .withUserConfiguration(
+                CoSecAuditAutoConfiguration::class.java,
+                CoSecAuditFallbackAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                context.getBeansOfType(AuditingAuthorization::class.java).assert().isEmpty()
+                context.getBean(Authorization::class.java).assert().isSameAs(customAuthorization)
+            }
+    }
+
+    @Test
     fun auditRemainsPrimaryWhenOpenTelemetryAutoConfigurationIsAbsent() {
         contextRunner
-            .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
             .withUserConfiguration(
+                AutoConfiguredAuthorizationTestConfiguration::class.java,
                 CoSecAuditAutoConfiguration::class.java,
                 CoSecAuditFallbackAutoConfiguration::class.java,
             )

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfigurationTest.kt
@@ -34,7 +34,10 @@ class CoSecAuditAutoConfigurationTest {
         contextRunner
             .withClassLoader(FilteredClassLoader("me.ahoo.cosec.opentelemetry.CoSecInstrumenter"))
             .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
-            .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
+            .withUserConfiguration(
+                CoSecAuditAutoConfiguration::class.java,
+                CoSecAuditFallbackAutoConfiguration::class.java,
+            )
             .run { context: AssertableApplicationContext ->
                 assertThat(context).hasSingleBean(AuditingAuthorization::class.java)
                 assertThat(context).hasSingleBean(LoggingAuditEventSink::class.java)
@@ -77,6 +80,20 @@ class CoSecAuditAutoConfigurationTest {
             .withUserConfiguration(CoSecAuditAutoConfiguration::class.java)
             .run { context: AssertableApplicationContext ->
                 assertThat(context).doesNotHaveBean(AuditingAuthorization::class.java)
+            }
+    }
+
+    @Test
+    fun auditRemainsPrimaryWhenOpenTelemetryAutoConfigurationIsAbsent() {
+        contextRunner
+            .withBean(CoSecAuthorizationAutoConfiguration.BEAN_NAME, Authorization::class.java, Supplier { mockk() })
+            .withUserConfiguration(
+                CoSecAuditAutoConfiguration::class.java,
+                CoSecAuditFallbackAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                assertThat(context).hasSingleBean(AuditingAuthorization::class.java)
+                assertThat(context.getBean(Authorization::class.java)).isInstanceOf(AuditingAuthorization::class.java)
             }
     }
 }

--- a/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
+++ b/cosec-webflux/src/main/kotlin/me/ahoo/cosec/webflux/ReactiveSecurityFilter.kt
@@ -26,6 +26,8 @@ import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
 import me.ahoo.cosec.policy.condition.part.RegexTimeoutException
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
+import me.ahoo.cosec.token.TokenVerificationContexts.getTokenVerificationException
+import me.ahoo.cosec.token.TokenVerificationContexts.setTokenVerificationException
 import me.ahoo.cosec.token.TokenVerificationException
 import me.ahoo.cosec.token.toAuthorizeResult
 import me.ahoo.cosec.webflux.ReactiveSecurityContexts.writeSecurityContext
@@ -75,7 +77,6 @@ abstract class ReactiveSecurityFilter(
             exchange.response.statusCode = HttpStatus.BAD_REQUEST
             return Mono.empty()
         }
-        var tokenVerificationException: TokenVerificationException? = null
         val securityContext =
             try {
                 securityContextParser.parse(request)
@@ -83,8 +84,9 @@ abstract class ReactiveSecurityFilter(
                 log.debug(verificationException) {
                     "Parse request to security context failed."
                 }
-                tokenVerificationException = verificationException
-                SimpleSecurityContext.anonymous()
+                SimpleSecurityContext.anonymous().also {
+                    it.setTokenVerificationException(verificationException)
+                }
             }
         securityContext.setRequest(request)
         exchange.setSecurityContext(securityContext)
@@ -106,7 +108,7 @@ abstract class ReactiveSecurityFilter(
                     exchange.response.statusCode = HttpStatus.FORBIDDEN
                 }
                 exchange.response.writeWithAuthorizeResult(
-                    tokenVerificationException?.toAuthorizeResult() ?: authorizeResult,
+                    securityContext.getTokenVerificationException()?.toAuthorizeResult() ?: authorizeResult,
                 ).then(Mono.empty())
             }.onAuthorizeError(exchange, request)
         return authorizedExchange.flatMap { authorized ->

--- a/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
+++ b/cosec-webflux/src/test/kotlin/me/ahoo/cosec/webflux/ReactiveAuthorizationFilterTest.kt
@@ -21,6 +21,7 @@ import io.mockk.runs
 import io.mockk.verify
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
 import me.ahoo.cosec.context.SecurityContextParser
@@ -30,6 +31,7 @@ import me.ahoo.cosec.jwt.Jwts
 import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
 import me.ahoo.cosec.policy.condition.part.RegexTimeoutException
 import me.ahoo.cosec.principal.SimplePrincipal
+import me.ahoo.cosec.token.TokenVerificationContexts.getTokenVerificationException
 import me.ahoo.cosec.token.TokenVerificationException
 import me.ahoo.cosec.webflux.ReactiveAuthorizationFilter.Companion.REACTIVE_AUTHORIZATION_FILTER_ORDER
 import me.ahoo.cosec.webflux.ServerWebExchanges.getSecurityContext
@@ -85,7 +87,10 @@ internal class ReactiveAuthorizationFilterTest {
     @Test
     fun filterWhenTokenInvalid() {
         val authorization = mockk<Authorization> {
-            every { authorize(any(), any()) } returns AuthorizeResult.EXPLICIT_DENY.toMono()
+            every { authorize(any(), any()) } answers {
+                secondArg<SecurityContext>().getTokenVerificationException().assert().isNotNull()
+                AuthorizeResult.EXPLICIT_DENY.toMono()
+            }
         }
         val securityContextParser = mockk<SecurityContextParser> {
             every { parse(any()) } throws TokenVerificationException()

--- a/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt
+++ b/cosec-webmvc/src/main/kotlin/me/ahoo/cosec/servlet/AbstractAuthorizationInterceptor.kt
@@ -25,6 +25,8 @@ import me.ahoo.cosec.context.SimpleSecurityContext
 import me.ahoo.cosec.context.request.RequestParser
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
 import me.ahoo.cosec.servlet.ServletRequests.setSecurityContext
+import me.ahoo.cosec.token.TokenVerificationContexts.getTokenVerificationException
+import me.ahoo.cosec.token.TokenVerificationContexts.setTokenVerificationException
 import me.ahoo.cosec.token.TokenVerificationException
 import me.ahoo.cosec.token.toAuthorizeResult
 import org.springframework.http.HttpStatus
@@ -62,13 +64,13 @@ abstract class AbstractAuthorizationInterceptor(
         servletResponse: HttpServletResponse
     ): Boolean {
         val request = requestParser.parse(servletRequest)
-        var tokenVerificationException: TokenVerificationException? = null
         val securityContext =
             try {
                 securityContextParser.parse(request)
             } catch (verificationException: TokenVerificationException) {
-                tokenVerificationException = verificationException
-                SimpleSecurityContext.anonymous()
+                SimpleSecurityContext.anonymous().also {
+                    it.setTokenVerificationException(verificationException)
+                }
             }
         securityContext.setRequest(request)
         SecurityContextHolder.setContext(securityContext)
@@ -85,7 +87,7 @@ abstract class AbstractAuthorizationInterceptor(
                     }
 
                     servletResponse.writeWithAuthorizeResult(
-                        tokenVerificationException?.toAuthorizeResult() ?: it,
+                        securityContext.getTokenVerificationException()?.toAuthorizeResult() ?: it,
                     )
                     return@map false
                 }

--- a/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
+++ b/cosec-webmvc/src/test/kotlin/me/ahoo/cosec/servlet/AuthorizationFilterTest.kt
@@ -23,6 +23,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import me.ahoo.cosec.api.authorization.Authorization
 import me.ahoo.cosec.api.authorization.AuthorizeResult
+import me.ahoo.cosec.api.context.SecurityContext
 import me.ahoo.cosec.api.context.request.RequestIdCapable
 import me.ahoo.cosec.api.principal.CoSecPrincipal
 import me.ahoo.cosec.context.AUTHORIZATION_HEADER_KEY
@@ -33,7 +34,9 @@ import me.ahoo.cosec.policy.condition.limiter.TooManyRequestsException
 import me.ahoo.cosec.policy.condition.part.RegexTimeoutException
 import me.ahoo.cosec.principal.SimpleTenantPrincipal
 import me.ahoo.cosec.servlet.ServletRequests.setSecurityContext
+import me.ahoo.cosec.token.TokenVerificationContexts.getTokenVerificationException
 import me.ahoo.cosec.token.TokenVerificationException
+import me.ahoo.test.asserts.assert
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
@@ -126,7 +129,10 @@ internal class AuthorizationFilterTest {
     @Test
     fun doFilterWhenTokenInvalid() {
         val authorization = mockk<Authorization> {
-            every { authorize(any(), any()) } returns AuthorizeResult.EXPLICIT_DENY.toMono()
+            every { authorize(any(), any()) } answers {
+                secondArg<SecurityContext>().getTokenVerificationException().assert().isNotNull()
+                AuthorizeResult.EXPLICIT_DENY.toMono()
+            }
         }
         val securityContextParser = mockk<SecurityContextParser> {
             every { parse(any()) } throws TokenVerificationException()

--- a/wiki/getting-started/configuration.md
+++ b/wiki/getting-started/configuration.md
@@ -156,6 +156,9 @@ to the logger `me.ahoo.cosec.audit` — denials at `WARN`, unexpected errors at
 `ERROR`, allows at `DEBUG` (so the default `INFO` level only surfaces denials).
 Set `logging.level.me.ahoo.cosec.audit=DEBUG` for full auditing, or register your
 own `AuditEventSink` bean to ship events to Kafka/Elasticsearch/your database.
+If you replace the default `Authorization` bean with your own, audit wiring steps
+aside automatically (the decorator only wraps the auto-configured
+`cosecAuthorization` bean).
 
 ### Gateway Properties (`cosec.authorization.gateway.*`)
 

--- a/wiki/getting-started/configuration.md
+++ b/wiki/getting-started/configuration.md
@@ -140,6 +140,23 @@ Controls the Redis-backed distributed rate limiter matchers (`redisRateLimiter`,
 
 Defined in `LimiterProperties` ([cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt:26](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt#L26)).
 
+### Audit Log (`cosec.audit.*`)
+
+Controls audit logging of authorization decisions.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `cosec.audit.enabled` | `Boolean` | `true` | Whether to audit authorization decisions. |
+
+Defined in `AuditProperties` ([cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt:26](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt#L26)).
+
+Every authorization decision is published as a structured `AuditEvent` to the
+`AuditEventSink` SPI. The default `LoggingAuditEventSink` writes single-line JSON
+to the logger `me.ahoo.cosec.audit` — denials at `WARN`, unexpected errors at
+`ERROR`, allows at `DEBUG` (so the default `INFO` level only surfaces denials).
+Set `logging.level.me.ahoo.cosec.audit=DEBUG` for full auditing, or register your
+own `AuditEventSink` bean to ship events to Kafka/Elasticsearch/your database.
+
 ### Gateway Properties (`cosec.authorization.gateway.*`)
 
 | Property | Type | Default | Description |

--- a/wiki/zh/getting-started/configuration.md
+++ b/wiki/zh/getting-started/configuration.md
@@ -140,6 +140,22 @@ flowchart TD
 
 定义在 `LimiterProperties`（[cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt:26](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/authorization/limiter/LimiterProperties.kt#L26)）中。
 
+### 审计日志（`cosec.audit.*`）
+
+控制授权决策的审计日志。
+
+| 属性 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `cosec.audit.enabled` | `Boolean` | `true` | 是否审计授权决策。 |
+
+定义在 `AuditProperties`（[cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt:26](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt#L26)）中。
+
+每次授权决策都会作为结构化 `AuditEvent` 发布到 `AuditEventSink` SPI。默认的
+`LoggingAuditEventSink` 以单行 JSON 输出到 logger `me.ahoo.cosec.audit`——拒绝为
+`WARN`、未预期异常为 `ERROR`、放行为 `DEBUG`（默认 `INFO` 级别下仅输出拒绝事件）。
+设置 `logging.level.me.ahoo.cosec.audit=DEBUG` 可开启全量审计；注册自定义
+`AuditEventSink` bean 可将事件接入 Kafka/ES/数据库。
+
 ### 网关属性（`cosec.authorization.gateway.*`）
 
 | 属性 | 类型 | 默认值 | 描述 |

--- a/wiki/zh/getting-started/configuration.md
+++ b/wiki/zh/getting-started/configuration.md
@@ -154,7 +154,9 @@ flowchart TD
 `LoggingAuditEventSink` 以单行 JSON 输出到 logger `me.ahoo.cosec.audit`——拒绝为
 `WARN`、未预期异常为 `ERROR`、放行为 `DEBUG`（默认 `INFO` 级别下仅输出拒绝事件）。
 设置 `logging.level.me.ahoo.cosec.audit=DEBUG` 可开启全量审计；注册自定义
-`AuditEventSink` bean 可将事件接入 Kafka/ES/数据库。
+`AuditEventSink` bean 可将事件接入 Kafka/ES/数据库。若你用自定义 bean 替换了默认的
+`Authorization`，审计装配会自动让位（装饰器仅包裹自动配置的 `cosecAuthorization`
+bean）。
 
 ### 网关属性（`cosec.authorization.gateway.*`）
 


### PR DESCRIPTION
## Summary

Adds a pluggable **audit log** for authorization decisions, following the design in `docs/superpowers/specs/2026-08-17-audit-log-design.md`.

Every `Authorization.authorize()` decision is emitted as a structured `AuditEvent` through the new `AuditEventSink` SPI — one implementation covers webflux/webmvc/gateway and any direct `Authorization` usage, with **zero changes to the integration modules** (decorator pattern, same seam as `TracingAuthorization`).

## What's included

- **cosec-api** `me.ahoo.cosec.api.audit`: `AuditEvent` (20 fields: identity / request / decision / matched policy or role permission / `elapsedNanos`), `AuditDecision` (ALLOW / EXPLICIT_DENY / IMPLICIT_DENY / TOO_MANY_REQUESTS / ERROR), `fun interface AuditEventSink`.
- **cosec-core** `me.ahoo.cosec.audit`:
  - `AuditingAuthorization` — decorator publishing via `doOnNext`/`doOnError`; all signals pass through unchanged; event construction **and** publishing are failure-isolated (audit can never alter an authorization outcome); wall-clock timing from Mono subscription to signal.
  - `AuditEventExtractor` — decision mapping table incl. matched policy/statement or role/permission from `VerifyContext`.
  - `LoggingAuditEventSink` (default) — single-line JSON to logger `me.ahoo.cosec.audit`; DENY/TOO_MANY_REQUESTS→WARN, ERROR→ERROR, ALLOW→DEBUG (default INFO level surfaces only denials); lazy serialization.
- **cosec-spring-boot-starter**: `cosec.audit.enabled` (default `true`, follows `LimiterProperties` pattern), auto-configuration with two classpath-conditional `AuditingAuthorization` bean variants, custom-sink override via `@ConditionalOnMissingBean(AuditEventSink)`, graceful skip when the default `Authorization` bean is replaced.
- **OTel composition**: chain is now `filters → TracingAuthorization → AuditingAuthorization → SimpleAuthorization` when both features are active — exactly one `@Primary` in every scenario (audit × otel × custom-bean matrix verified by tests); behavior unchanged when audit is disabled.
- **Docs**: audit sections added to EN + ZH `getting-started/configuration.md`.

## Test evidence

TDD throughout (every behavior RED-first). Full build: **409 tests, 0 failures** (1 pre-existing skip), detekt clean.

## Notes for reviewers

- Two tiny follow-ups parked as backlog (non-blocking): extractor test cross-null assertion asymmetry; hardening `auditedTracingAuthorization`'s condition to bean-name matching for a pathological hand-registered-bean edge case.