### PR TITLE
feat: add Kafka audit sink

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,6 +32,25 @@ jobs:
       - name: Test CoSec-Core
         run: ./gradlew cosec-core:clean cosec-core:check
 
+  cosec-kafka-test:
+    name: CoSec Kafka Test
+    needs: [ cosec-core-test ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Test CoSec-Kafka
+        run: ./gradlew cosec-kafka:clean cosec-kafka:check
+
   cosec-opentelemetry-test:
     name: CoSec OpenTelemetry Test
     needs: [ cosec-core-test ]

--- a/cosec-kafka/build.gradle.kts
+++ b/cosec-kafka/build.gradle.kts
@@ -11,22 +11,8 @@
  * limitations under the License.
  */
 
-rootProject.name = "CoSec"
-
-include(":cosec-bom")
-include(":cosec-dependencies")
-include(":cosec-api")
-include(":cosec-core")
-include(":cosec-jwt")
-include(":cosec-cocache")
-include(":cosec-social")
-include(":cosec-webmvc")
-include(":cosec-webflux")
-include(":cosec-spring-boot-starter")
-include(":cosec-gateway")
-include(":cosec-gateway-server")
-include(":cosec-opentelemetry")
-include(":cosec-ip2region")
-include(":code-coverage-report")
-include(":cosec-openapi")
-include(":cosec-kafka")
+dependencies {
+    api(project(":cosec-api"))
+    api("org.springframework.kafka:spring-kafka")
+    implementation(project(":cosec-core"))
+}

--- a/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
+++ b/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
@@ -21,10 +21,12 @@ import org.springframework.beans.factory.DisposableBean
 import org.springframework.kafka.core.KafkaOperations
 import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
+import java.time.Duration
 import java.util.concurrent.RejectedExecutionException
 
 private const val MAX_PENDING_AUDIT_EVENTS = 1024
 private const val KAFKA_AUDIT_SCHEDULER_NAME = "cosec-kafka-audit"
+private val DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10)
 
 class KafkaAuditEventSink(
     private val kafkaOperations: KafkaOperations<String, String>,
@@ -34,6 +36,7 @@ class KafkaAuditEventSink(
         MAX_PENDING_AUDIT_EVENTS,
         KAFKA_AUDIT_SCHEDULER_NAME,
     ),
+    private val shutdownTimeout: Duration = DEFAULT_SHUTDOWN_TIMEOUT,
 ) : AuditEventSink,
     DisposableBean {
     init {
@@ -64,8 +67,14 @@ class KafkaAuditEventSink(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun destroy() {
-        scheduler.dispose()
+        try {
+            scheduler.disposeGracefully().block(shutdownTimeout)
+        } catch (error: RuntimeException) {
+            log.warn(error) { "Timed out while draining the Kafka audit queue; forcing shutdown." }
+            scheduler.dispose()
+        }
     }
 
     private fun logFailure(error: Throwable) {

--- a/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
+++ b/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
@@ -21,11 +21,19 @@ import org.springframework.beans.factory.DisposableBean
 import org.springframework.kafka.core.KafkaOperations
 import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
+import java.util.concurrent.RejectedExecutionException
+
+private const val MAX_PENDING_AUDIT_EVENTS = 1024
+private const val KAFKA_AUDIT_SCHEDULER_NAME = "cosec-kafka-audit"
 
 class KafkaAuditEventSink(
     private val kafkaOperations: KafkaOperations<String, String>,
     private val topic: String,
-    private val scheduler: Scheduler = Schedulers.newSingle("cosec-kafka-audit"),
+    private val scheduler: Scheduler = Schedulers.newBoundedElastic(
+        1,
+        MAX_PENDING_AUDIT_EVENTS,
+        KAFKA_AUDIT_SCHEDULER_NAME,
+    ),
 ) : AuditEventSink,
     DisposableBean {
     init {
@@ -34,21 +42,25 @@ class KafkaAuditEventSink(
 
     @Suppress("TooGenericExceptionCaught")
     override fun publish(event: AuditEvent) {
-        // ponytail: one scheduler preserves audit order; shard by key if send throughput becomes a bottleneck.
-        scheduler.schedule {
-            try {
-                kafkaOperations.send(
-                    topic,
-                    CoSecJsonSerializer.writeValueAsString(arrayOf(event.tenantId, event.principalId)),
-                    CoSecJsonSerializer.writeValueAsString(event),
-                ).whenComplete { _, error ->
-                    if (error != null) {
-                        logFailure(error)
+        try {
+            // ponytail: one bounded scheduler preserves order; shard by key if throughput becomes a bottleneck.
+            scheduler.schedule {
+                try {
+                    kafkaOperations.send(
+                        topic,
+                        CoSecJsonSerializer.writeValueAsString(arrayOf(event.tenantId, event.principalId)),
+                        CoSecJsonSerializer.writeValueAsString(event),
+                    ).whenComplete { _, error ->
+                        if (error != null) {
+                            logFailure(error)
+                        }
                     }
+                } catch (error: Exception) {
+                    logFailure(error)
                 }
-            } catch (error: Exception) {
-                logFailure(error)
             }
+        } catch (error: RejectedExecutionException) {
+            log.warn(error) { "Dropped audit event because the Kafka audit queue is full or shutting down." }
         }
     }
 

--- a/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
+++ b/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
@@ -18,25 +18,39 @@ import me.ahoo.cosec.api.audit.AuditEvent
 import me.ahoo.cosec.api.audit.AuditEventSink
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
 import org.springframework.kafka.core.KafkaOperations
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
 
 class KafkaAuditEventSink(
     private val kafkaOperations: KafkaOperations<String, String>,
     private val topic: String,
+    private val scheduler: Scheduler = Schedulers.boundedElastic(),
 ) : AuditEventSink {
     init {
         require(topic.isNotBlank()) { "topic must not be blank." }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun publish(event: AuditEvent) {
-        kafkaOperations.send(
-            topic,
-            "${event.tenantId}:${event.principalId}",
-            CoSecJsonSerializer.writeValueAsString(event),
-        ).whenComplete { _, error ->
-            if (error != null) {
-                log.warn(error) { "Failed to publish audit event to Kafka topic [$topic]." }
+        scheduler.schedule {
+            try {
+                kafkaOperations.send(
+                    topic,
+                    CoSecJsonSerializer.writeValueAsString(arrayOf(event.tenantId, event.principalId)),
+                    CoSecJsonSerializer.writeValueAsString(event),
+                ).whenComplete { _, error ->
+                    if (error != null) {
+                        logFailure(error)
+                    }
+                }
+            } catch (error: Exception) {
+                logFailure(error)
             }
         }
+    }
+
+    private fun logFailure(error: Throwable) {
+        log.warn(error) { "Failed to publish audit event to Kafka topic [$topic]." }
     }
 
     companion object {

--- a/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
+++ b/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
@@ -17,6 +17,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.cosec.api.audit.AuditEvent
 import me.ahoo.cosec.api.audit.AuditEventSink
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
+import org.springframework.beans.factory.DisposableBean
 import org.springframework.kafka.core.KafkaOperations
 import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
@@ -24,14 +25,16 @@ import reactor.core.scheduler.Schedulers
 class KafkaAuditEventSink(
     private val kafkaOperations: KafkaOperations<String, String>,
     private val topic: String,
-    private val scheduler: Scheduler = Schedulers.boundedElastic(),
-) : AuditEventSink {
+    private val scheduler: Scheduler = Schedulers.newSingle("cosec-kafka-audit"),
+) : AuditEventSink,
+    DisposableBean {
     init {
         require(topic.isNotBlank()) { "topic must not be blank." }
     }
 
     @Suppress("TooGenericExceptionCaught")
     override fun publish(event: AuditEvent) {
+        // ponytail: one scheduler preserves audit order; shard by key if send throughput becomes a bottleneck.
         scheduler.schedule {
             try {
                 kafkaOperations.send(
@@ -47,6 +50,10 @@ class KafkaAuditEventSink(
                 logFailure(error)
             }
         }
+    }
+
+    override fun destroy() {
+        scheduler.dispose()
     }
 
     private fun logFailure(error: Throwable) {

--- a/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
+++ b/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
@@ -23,6 +23,7 @@ import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 import java.time.Duration
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.atomic.AtomicBoolean
 
 private const val MAX_PENDING_AUDIT_EVENTS = 1024
 private const val KAFKA_AUDIT_SCHEDULER_NAME = "cosec-kafka-audit"
@@ -31,11 +32,7 @@ private val DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10)
 class KafkaAuditEventSink(
     private val kafkaOperations: KafkaOperations<String, String>,
     private val topic: String,
-    private val scheduler: Scheduler = Schedulers.newBoundedElastic(
-        1,
-        MAX_PENDING_AUDIT_EVENTS,
-        KAFKA_AUDIT_SCHEDULER_NAME,
-    ),
+    scheduler: Scheduler? = null,
     private val shutdownTimeout: Duration = DEFAULT_SHUTDOWN_TIMEOUT,
 ) : AuditEventSink,
     DisposableBean {
@@ -43,11 +40,20 @@ class KafkaAuditEventSink(
         require(topic.isNotBlank()) { "topic must not be blank." }
     }
 
+    private val ownsScheduler = scheduler == null
+    private val scheduler = scheduler ?: Schedulers.newBoundedElastic(
+        1,
+        MAX_PENDING_AUDIT_EVENTS,
+        KAFKA_AUDIT_SCHEDULER_NAME,
+    )
+    private val queueFullWarningLogged = AtomicBoolean()
+
     @Suppress("TooGenericExceptionCaught")
     override fun publish(event: AuditEvent) {
         try {
             // ponytail: one bounded scheduler preserves order; shard by key if throughput becomes a bottleneck.
             scheduler.schedule {
+                queueFullWarningLogged.set(false)
                 try {
                     kafkaOperations.send(
                         topic,
@@ -62,13 +68,18 @@ class KafkaAuditEventSink(
                     logFailure(error)
                 }
             }
-        } catch (error: RejectedExecutionException) {
-            log.warn(error) { "Dropped audit event because the Kafka audit queue is full or shutting down." }
+        } catch (_: RejectedExecutionException) {
+            if (queueFullWarningLogged.compareAndSet(false, true)) {
+                log.warn { "Dropping audit events because the Kafka audit queue is full or shutting down." }
+            }
         }
     }
 
     @Suppress("TooGenericExceptionCaught")
     override fun destroy() {
+        if (!ownsScheduler) {
+            return
+        }
         try {
             scheduler.disposeGracefully().block(shutdownTimeout)
         } catch (error: RuntimeException) {

--- a/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
+++ b/cosec-kafka/src/main/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSink.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.kafka
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.cosec.api.audit.AuditEvent
+import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.serialization.CoSecJsonSerializer
+import org.springframework.kafka.core.KafkaOperations
+
+class KafkaAuditEventSink(
+    private val kafkaOperations: KafkaOperations<String, String>,
+    private val topic: String,
+) : AuditEventSink {
+    init {
+        require(topic.isNotBlank()) { "topic must not be blank." }
+    }
+
+    override fun publish(event: AuditEvent) {
+        kafkaOperations.send(
+            topic,
+            "${event.tenantId}:${event.principalId}",
+            CoSecJsonSerializer.writeValueAsString(event),
+        ).whenComplete { _, error ->
+            if (error != null) {
+                log.warn(error) { "Failed to publish audit event to Kafka topic [$topic]." }
+            }
+        }
+    }
+
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+}

--- a/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
+++ b/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
@@ -22,16 +22,22 @@ import me.ahoo.cosec.api.audit.AuditEvent
 import me.ahoo.cosec.api.audit.AuditMatch
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
 import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.kafka.core.KafkaOperations
 import org.springframework.kafka.support.SendResult
+import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 class KafkaAuditEventSinkTest {
+    private val sinks = mutableListOf<KafkaAuditEventSink>()
+
     private val event = AuditEvent(
         timestamp = Instant.parse("2026-08-18T00:00:00Z"),
         tenantId = "tenant-1",
@@ -52,6 +58,18 @@ class KafkaAuditEventSinkTest {
         match = AuditMatch(policyId = "orders", statementName = "read"),
     )
 
+    @AfterEach
+    fun destroySinks() {
+        sinks.forEach(KafkaAuditEventSink::destroy)
+    }
+
+    private fun sink(
+        kafkaOperations: KafkaOperations<String, String>,
+        scheduler: Scheduler = Schedulers.immediate(),
+    ): KafkaAuditEventSink {
+        return KafkaAuditEventSink(kafkaOperations, "cosec-audit", scheduler).also(sinks::add)
+    }
+
     @Test
     fun publishSchedulesJsonSend() {
         val result = CompletableFuture<SendResult<String, String>>()
@@ -60,7 +78,7 @@ class KafkaAuditEventSinkTest {
         }
         var scheduledTask: Runnable? = null
         val scheduler = Schedulers.fromExecutor(Executor { scheduledTask = it })
-        val sink = KafkaAuditEventSink(kafkaOperations, "cosec-audit", scheduler)
+        val sink = sink(kafkaOperations, scheduler)
 
         sink.publish(event)
 
@@ -82,7 +100,7 @@ class KafkaAuditEventSinkTest {
         val kafkaOperations = mockk<KafkaOperations<String, String>> {
             every { send(any(), capture(keys), any()) } returns CompletableFuture.completedFuture(mockk())
         }
-        val sink = KafkaAuditEventSink(kafkaOperations, "cosec-audit", Schedulers.immediate())
+        val sink = sink(kafkaOperations)
 
         sink.publish(event.copy(tenantId = "a", principalId = "b:c"))
         sink.publish(event.copy(tenantId = "a:b", principalId = "c"))
@@ -100,7 +118,7 @@ class KafkaAuditEventSinkTest {
             )
         }
 
-        KafkaAuditEventSink(kafkaOperations, "cosec-audit", Schedulers.immediate()).publish(event)
+        sink(kafkaOperations).publish(event)
     }
 
     @Test
@@ -109,7 +127,7 @@ class KafkaAuditEventSinkTest {
             every { send(any(), any(), any()) } throws IllegalStateException("Kafka unavailable")
         }
 
-        KafkaAuditEventSink(kafkaOperations, "cosec-audit", Schedulers.immediate()).publish(event)
+        sink(kafkaOperations).publish(event)
     }
 
     @Test
@@ -117,5 +135,27 @@ class KafkaAuditEventSinkTest {
         assertThrows<IllegalArgumentException> {
             KafkaAuditEventSink(mockk(), " ")
         }
+    }
+
+    @Test
+    fun serialSchedulerPreservesSendOrder() {
+        val values = mutableListOf<String>()
+        val sent = CountDownLatch(2)
+        val kafkaOperations = mockk<KafkaOperations<String, String>> {
+            every { send(any(), any(), capture(values)) } answers {
+                sent.countDown()
+                CompletableFuture.completedFuture(mockk())
+            }
+        }
+        val sink = KafkaAuditEventSink(kafkaOperations, "cosec-audit").also(sinks::add)
+        val first = event.copy(requestId = "request-1")
+        val second = event.copy(requestId = "request-2")
+
+        sink.publish(first)
+        sink.publish(second)
+
+        sent.await(5, TimeUnit.SECONDS).assert().isTrue()
+        values[0].assert().isEqualTo(CoSecJsonSerializer.writeValueAsString(first))
+        values[1].assert().isEqualTo(CoSecJsonSerializer.writeValueAsString(second))
     }
 }

--- a/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
+++ b/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
@@ -27,8 +27,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.kafka.core.KafkaOperations
 import org.springframework.kafka.support.SendResult
+import reactor.core.publisher.Mono
 import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
@@ -170,5 +172,52 @@ class KafkaAuditEventSinkTest {
         sink(kafkaOperations, scheduler).publish(event)
 
         verify(exactly = 0) { kafkaOperations.send(any(), any(), any()) }
+    }
+
+    @Test
+    fun destroyDrainsAcceptedTasks() {
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val sent = CountDownLatch(2)
+        var sendCount = 0
+        val kafkaOperations = mockk<KafkaOperations<String, String>> {
+            every { send(any(), any(), any()) } answers {
+                if (sendCount++ == 0) {
+                    firstStarted.countDown()
+                    releaseFirst.await(5, TimeUnit.SECONDS)
+                }
+                sent.countDown()
+                CompletableFuture.completedFuture(mockk())
+            }
+        }
+        val sink = KafkaAuditEventSink(kafkaOperations, "cosec-audit")
+
+        sink.publish(event.copy(requestId = "request-1"))
+        firstStarted.await(5, TimeUnit.SECONDS).assert().isTrue()
+        sink.publish(event.copy(requestId = "request-2"))
+        val destroyed = CompletableFuture.runAsync(sink::destroy)
+        destroyed.isDone.assert().isFalse()
+        releaseFirst.countDown()
+
+        destroyed.get(5, TimeUnit.SECONDS)
+        sent.await(5, TimeUnit.SECONDS).assert().isTrue()
+        verify(exactly = 2) { kafkaOperations.send(any(), any(), any()) }
+    }
+
+    @Test
+    fun destroyForcesShutdownAfterTimeout() {
+        val scheduler = mockk<Scheduler>(relaxed = true) {
+            every { disposeGracefully() } returns Mono.never()
+        }
+        val sink = KafkaAuditEventSink(
+            kafkaOperations = mockk(),
+            topic = "cosec-audit",
+            scheduler = scheduler,
+            shutdownTimeout = Duration.ofMillis(1),
+        )
+
+        sink.destroy()
+
+        verify(exactly = 1) { scheduler.dispose() }
     }
 }

--- a/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
+++ b/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
@@ -23,10 +23,13 @@ import me.ahoo.cosec.api.audit.AuditMatch
 import me.ahoo.cosec.serialization.CoSecJsonSerializer
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.kafka.core.KafkaOperations
 import org.springframework.kafka.support.SendResult
+import reactor.core.scheduler.Schedulers
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
 
 class KafkaAuditEventSinkTest {
     private val event = AuditEvent(
@@ -50,23 +53,43 @@ class KafkaAuditEventSinkTest {
     )
 
     @Test
-    fun publishJsonWithoutWaitingForKafka() {
+    fun publishSchedulesJsonSend() {
         val result = CompletableFuture<SendResult<String, String>>()
         val kafkaOperations = mockk<KafkaOperations<String, String>> {
             every { send(any(), any(), any()) } returns result
         }
-        val sink = KafkaAuditEventSink(kafkaOperations, "cosec-audit")
+        var scheduledTask: Runnable? = null
+        val scheduler = Schedulers.fromExecutor(Executor { scheduledTask = it })
+        val sink = KafkaAuditEventSink(kafkaOperations, "cosec-audit", scheduler)
 
         sink.publish(event)
 
+        verify(exactly = 0) { kafkaOperations.send(any(), any(), any()) }
+        scheduledTask!!.run()
         verify(exactly = 1) {
             kafkaOperations.send(
                 "cosec-audit",
-                "tenant-1:principal-1",
+                "[\"tenant-1\",\"principal-1\"]",
                 CoSecJsonSerializer.writeValueAsString(event),
             )
         }
-        result.isDone.assert().isFalse()
+        result.complete(mockk())
+    }
+
+    @Test
+    fun keysAreUnambiguous() {
+        val keys = mutableListOf<String>()
+        val kafkaOperations = mockk<KafkaOperations<String, String>> {
+            every { send(any(), capture(keys), any()) } returns CompletableFuture.completedFuture(mockk())
+        }
+        val sink = KafkaAuditEventSink(kafkaOperations, "cosec-audit", Schedulers.immediate())
+
+        sink.publish(event.copy(tenantId = "a", principalId = "b:c"))
+        sink.publish(event.copy(tenantId = "a:b", principalId = "c"))
+
+        keys[0].assert().isEqualTo("[\"a\",\"b:c\"]")
+        keys[1].assert().isEqualTo("[\"a:b\",\"c\"]")
+        keys.toSet().assert().hasSize(2)
     }
 
     @Test
@@ -77,6 +100,22 @@ class KafkaAuditEventSinkTest {
             )
         }
 
-        KafkaAuditEventSink(kafkaOperations, "cosec-audit").publish(event)
+        KafkaAuditEventSink(kafkaOperations, "cosec-audit", Schedulers.immediate()).publish(event)
+    }
+
+    @Test
+    fun synchronousFailureDoesNotEscapeScheduledTask() {
+        val kafkaOperations = mockk<KafkaOperations<String, String>> {
+            every { send(any(), any(), any()) } throws IllegalStateException("Kafka unavailable")
+        }
+
+        KafkaAuditEventSink(kafkaOperations, "cosec-audit", Schedulers.immediate()).publish(event)
+    }
+
+    @Test
+    fun blankTopicIsRejected() {
+        assertThrows<IllegalArgumentException> {
+            KafkaAuditEventSink(mockk(), " ")
+        }
     }
 }

--- a/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
+++ b/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.kafka.core.KafkaOperations
 import org.springframework.kafka.support.SendResult
-import reactor.core.publisher.Mono
 import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 import java.time.Duration
@@ -163,15 +162,28 @@ class KafkaAuditEventSinkTest {
     }
 
     @Test
-    fun rejectedTaskIsDropped() {
+    fun rejectedTasksAreDropped() {
         val scheduler = mockk<Scheduler>(relaxed = true) {
             every { schedule(any<Runnable>()) } throws RejectedExecutionException("Queue full")
         }
         val kafkaOperations = mockk<KafkaOperations<String, String>>(relaxed = true)
+        val sink = sink(kafkaOperations, scheduler)
 
-        sink(kafkaOperations, scheduler).publish(event)
+        sink.publish(event)
+        sink.publish(event)
 
         verify(exactly = 0) { kafkaOperations.send(any(), any(), any()) }
+    }
+
+    @Test
+    fun destroyDoesNotDisposeCallerScheduler() {
+        val scheduler = mockk<Scheduler>(relaxed = true)
+        val sink = KafkaAuditEventSink(mockk(), "cosec-audit", scheduler)
+
+        sink.destroy()
+
+        verify(exactly = 0) { scheduler.disposeGracefully() }
+        verify(exactly = 0) { scheduler.dispose() }
     }
 
     @Test
@@ -206,18 +218,24 @@ class KafkaAuditEventSinkTest {
 
     @Test
     fun destroyForcesShutdownAfterTimeout() {
-        val scheduler = mockk<Scheduler>(relaxed = true) {
-            every { disposeGracefully() } returns Mono.never()
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val kafkaOperations = mockk<KafkaOperations<String, String>> {
+            every { send(any(), any(), any()) } answers {
+                started.countDown()
+                release.await(5, TimeUnit.SECONDS)
+                CompletableFuture.completedFuture(mockk())
+            }
         }
         val sink = KafkaAuditEventSink(
-            kafkaOperations = mockk(),
+            kafkaOperations = kafkaOperations,
             topic = "cosec-audit",
-            scheduler = scheduler,
             shutdownTimeout = Duration.ofMillis(1),
         )
 
+        sink.publish(event)
+        started.await(5, TimeUnit.SECONDS).assert().isTrue()
         sink.destroy()
-
-        verify(exactly = 1) { scheduler.dispose() }
+        release.countDown()
     }
 }

--- a/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
+++ b/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.kafka
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.cosec.api.audit.AuditDecision
+import me.ahoo.cosec.api.audit.AuditDevice
+import me.ahoo.cosec.api.audit.AuditEvent
+import me.ahoo.cosec.api.audit.AuditMatch
+import me.ahoo.cosec.serialization.CoSecJsonSerializer
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.core.KafkaOperations
+import org.springframework.kafka.support.SendResult
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+
+class KafkaAuditEventSinkTest {
+    private val event = AuditEvent(
+        timestamp = Instant.parse("2026-08-18T00:00:00Z"),
+        tenantId = "tenant-1",
+        principalId = "principal-1",
+        authenticated = true,
+        roles = setOf("admin"),
+        policies = setOf("orders"),
+        appId = "app-1",
+        spaceId = "space-1",
+        device = AuditDevice(id = "device-1", userAgent = "test-agent"),
+        requestId = "request-1",
+        remoteIp = "127.0.0.1",
+        method = "GET",
+        path = "/orders/1",
+        decision = AuditDecision.ALLOW,
+        reason = "Allow",
+        elapsedNanos = 100,
+        match = AuditMatch(policyId = "orders", statementName = "read"),
+    )
+
+    @Test
+    fun publishJsonWithoutWaitingForKafka() {
+        val result = CompletableFuture<SendResult<String, String>>()
+        val kafkaOperations = mockk<KafkaOperations<String, String>> {
+            every { send(any(), any(), any()) } returns result
+        }
+        val sink = KafkaAuditEventSink(kafkaOperations, "cosec-audit")
+
+        sink.publish(event)
+
+        verify(exactly = 1) {
+            kafkaOperations.send(
+                "cosec-audit",
+                "tenant-1:principal-1",
+                CoSecJsonSerializer.writeValueAsString(event),
+            )
+        }
+        result.isDone.assert().isFalse()
+    }
+
+    @Test
+    fun asyncFailureDoesNotEscapePublish() {
+        val kafkaOperations = mockk<KafkaOperations<String, String>> {
+            every { send(any(), any(), any()) } returns CompletableFuture.failedFuture(
+                IllegalStateException("Kafka unavailable"),
+            )
+        }
+
+        KafkaAuditEventSink(kafkaOperations, "cosec-audit").publish(event)
+    }
+}

--- a/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
+++ b/cosec-kafka/src/test/kotlin/me/ahoo/cosec/kafka/KafkaAuditEventSinkTest.kt
@@ -33,6 +33,7 @@ import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 
 class KafkaAuditEventSinkTest {
@@ -157,5 +158,17 @@ class KafkaAuditEventSinkTest {
         sent.await(5, TimeUnit.SECONDS).assert().isTrue()
         values[0].assert().isEqualTo(CoSecJsonSerializer.writeValueAsString(first))
         values[1].assert().isEqualTo(CoSecJsonSerializer.writeValueAsString(second))
+    }
+
+    @Test
+    fun rejectedTaskIsDropped() {
+        val scheduler = mockk<Scheduler>(relaxed = true) {
+            every { schedule(any<Runnable>()) } throws RejectedExecutionException("Queue full")
+        }
+        val kafkaOperations = mockk<KafkaOperations<String, String>>(relaxed = true)
+
+        sink(kafkaOperations, scheduler).publish(event)
+
+        verify(exactly = 0) { kafkaOperations.send(any(), any(), any()) }
     }
 }

--- a/cosec-spring-boot-starter/build.gradle.kts
+++ b/cosec-spring-boot-starter/build.gradle.kts
@@ -47,6 +47,10 @@ java {
         usingSourceSet(sourceSets[SourceSet.MAIN_SOURCE_SET_NAME])
         capability(group.toString(), "openapi-support", version.toString())
     }
+    registerFeature("kafkaSupport") {
+        usingSourceSet(sourceSets[SourceSet.MAIN_SOURCE_SET_NAME])
+        capability(group.toString(), "kafka-support", version.toString())
+    }
 }
 dependencies {
     kapt(platform(project(":cosec-dependencies")))
@@ -64,6 +68,8 @@ dependencies {
     "openapiSupportImplementation"(project(":cosec-openapi"))
     "openapiSupportImplementation"("org.springframework.boot:spring-boot-starter-actuator")
     "openapiSupportImplementation"("org.springdoc:springdoc-openapi-starter-common")
+    "kafkaSupportImplementation"(project(":cosec-kafka"))
+    "kafkaSupportImplementation"("org.springframework.boot:spring-boot-starter-kafka")
     api("org.springframework.boot:spring-boot-starter")
     api("org.springframework.boot:spring-boot-starter-jackson")
     kapt("org.springframework.boot:spring-boot-configuration-processor")

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfiguration.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.audit.kafka
+
+import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.kafka.KafkaAuditEventSink
+import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
+import me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration
+import me.ahoo.cosec.spring.boot.starter.audit.ConditionalOnAuditEnabled
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.kafka.core.KafkaTemplate
+
+@AutoConfiguration(
+    afterName = ["org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration"],
+    before = [CoSecAuditAutoConfiguration::class],
+)
+@ConditionalOnCoSecEnabled
+@ConditionalOnAuditEnabled
+@ConditionalOnClass(KafkaAuditEventSink::class, KafkaTemplate::class)
+@ConditionalOnSingleCandidate(KafkaTemplate::class)
+@ConditionalOnMissingBean(AuditEventSink::class)
+@ConditionalOnProperty(
+    prefix = KafkaAuditProperties.PREFIX,
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+@EnableConfigurationProperties(KafkaAuditProperties::class)
+class CoSecKafkaAuditAutoConfiguration {
+    @Bean
+    fun kafkaAuditEventSink(
+        kafkaTemplate: KafkaTemplate<String, String>,
+        properties: KafkaAuditProperties,
+    ): KafkaAuditEventSink {
+        return KafkaAuditEventSink(kafkaTemplate, properties.topic)
+    }
+}

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfiguration.kt
@@ -21,10 +21,10 @@ import me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration
 import me.ahoo.cosec.spring.boot.starter.audit.ConditionalOnAuditEnabled
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.kafka.core.KafkaTemplate
@@ -36,7 +36,7 @@ import org.springframework.kafka.core.KafkaTemplate
 @ConditionalOnCoSecEnabled
 @ConditionalOnAuditEnabled
 @ConditionalOnClass(KafkaAuditEventSink::class, KafkaTemplate::class)
-@ConditionalOnSingleCandidate(KafkaTemplate::class)
+@ConditionalOnBean(KafkaTemplate::class)
 @ConditionalOnMissingBean(AuditEventSink::class)
 @ConditionalOnProperty(
     prefix = KafkaAuditProperties.PREFIX,

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfiguration.kt
@@ -14,10 +14,12 @@
 package me.ahoo.cosec.spring.boot.starter.audit.kafka
 
 import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.audit.LoggingAuditEventSink
 import me.ahoo.cosec.kafka.KafkaAuditEventSink
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
 import me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration
 import me.ahoo.cosec.spring.boot.starter.audit.ConditionalOnAuditEnabled
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -46,9 +48,10 @@ import org.springframework.kafka.core.KafkaTemplate
 class CoSecKafkaAuditAutoConfiguration {
     @Bean
     fun kafkaAuditEventSink(
-        kafkaTemplate: KafkaTemplate<String, String>,
+        kafkaTemplates: ObjectProvider<KafkaTemplate<String, String>>,
         properties: KafkaAuditProperties,
-    ): KafkaAuditEventSink {
+    ): AuditEventSink {
+        val kafkaTemplate = kafkaTemplates.getIfUnique() ?: return LoggingAuditEventSink()
         return KafkaAuditEventSink(kafkaTemplate, properties.topic)
     }
 }

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/KafkaAuditProperties.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/KafkaAuditProperties.kt
@@ -11,22 +11,19 @@
  * limitations under the License.
  */
 
-rootProject.name = "CoSec"
+package me.ahoo.cosec.spring.boot.starter.audit.kafka
 
-include(":cosec-bom")
-include(":cosec-dependencies")
-include(":cosec-api")
-include(":cosec-core")
-include(":cosec-jwt")
-include(":cosec-cocache")
-include(":cosec-social")
-include(":cosec-webmvc")
-include(":cosec-webflux")
-include(":cosec-spring-boot-starter")
-include(":cosec-gateway")
-include(":cosec-gateway-server")
-include(":cosec-opentelemetry")
-include(":cosec-ip2region")
-include(":code-coverage-report")
-include(":cosec-openapi")
-include(":cosec-kafka")
+import me.ahoo.cosec.spring.boot.starter.EnabledCapable
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+@ConfigurationProperties(KafkaAuditProperties.PREFIX)
+data class KafkaAuditProperties(
+    @DefaultValue("true") override var enabled: Boolean = true,
+    @DefaultValue(DEFAULT_TOPIC) var topic: String = DEFAULT_TOPIC,
+) : EnabledCapable {
+    companion object {
+        const val PREFIX: String = "cosec.audit.kafka"
+        const val DEFAULT_TOPIC: String = "cosec-audit"
+    }
+}

--- a/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/cosec-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,5 +14,6 @@ me.ahoo.cosec.spring.boot.starter.ip2region.Ip2RegionAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.actuate.CoSecEndpointAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.openapi.CoSecOpenAPIAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.authorization.limiter.CoSecRedisRateLimiterAutoConfiguration
+me.ahoo.cosec.spring.boot.starter.audit.kafka.CoSecKafkaAuditAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration
 me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditFallbackAutoConfiguration

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfigurationTest.kt
@@ -24,8 +24,18 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.core.KafkaTemplate
 import java.util.function.Supplier
+
+private class DomainEvent
+
+@Configuration(proxyBeanMethods = false)
+private class DomainKafkaTemplateTestConfiguration {
+    @Bean
+    fun domainKafkaTemplate(): KafkaTemplate<String, DomainEvent> = mockk(relaxed = true)
+}
 
 class CoSecKafkaAuditAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
@@ -62,6 +72,37 @@ class CoSecKafkaAuditAutoConfigurationTest {
         contextRunner.run { context ->
             context.getBean(AuditEventSink::class.java).assert().isInstanceOf(LoggingAuditEventSink::class.java)
         }
+    }
+
+    @Test
+    fun nonStringKafkaTemplateFallsBackToLogging() {
+        contextRunner
+            .withUserConfiguration(DomainKafkaTemplateTestConfiguration::class.java)
+            .run { context ->
+                context.getBean(AuditEventSink::class.java).assert().isInstanceOf(LoggingAuditEventSink::class.java)
+            }
+    }
+
+    @Test
+    fun customTopicIsBound() {
+        contextRunner
+            .withKafkaTemplate()
+            .withPropertyValues("cosec.audit.kafka.topic=security-audit")
+            .run { context ->
+                context.getBean(KafkaAuditProperties::class.java).topic.assert().isEqualTo("security-audit")
+            }
+    }
+
+    @Test
+    fun kafkaPropertiesDefaults() {
+        val properties = KafkaAuditProperties()
+
+        properties.enabled.assert().isTrue()
+        properties.topic.assert().isEqualTo(KafkaAuditProperties.DEFAULT_TOPIC)
+        properties.enabled = false
+        properties.topic = "security-audit"
+        properties.enabled.assert().isFalse()
+        properties.topic.assert().isEqualTo("security-audit")
     }
 
     @Test

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfigurationTest.kt
@@ -37,6 +37,15 @@ private class DomainKafkaTemplateTestConfiguration {
     fun domainKafkaTemplate(): KafkaTemplate<String, DomainEvent> = mockk(relaxed = true)
 }
 
+@Configuration(proxyBeanMethods = false)
+private class HeterogeneousKafkaTemplateTestConfiguration {
+    @Bean
+    fun stringKafkaTemplate(): KafkaTemplate<String, String> = mockk(relaxed = true)
+
+    @Bean
+    fun domainKafkaTemplate(): KafkaTemplate<String, DomainEvent> = mockk(relaxed = true)
+}
+
 class CoSecKafkaAuditAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
         .withConfiguration(
@@ -80,6 +89,15 @@ class CoSecKafkaAuditAutoConfigurationTest {
             .withUserConfiguration(DomainKafkaTemplateTestConfiguration::class.java)
             .run { context ->
                 context.getBean(AuditEventSink::class.java).assert().isInstanceOf(LoggingAuditEventSink::class.java)
+            }
+    }
+
+    @Test
+    fun heterogeneousKafkaTemplatesSelectStringTemplate() {
+        contextRunner
+            .withUserConfiguration(HeterogeneousKafkaTemplateTestConfiguration::class.java)
+            .run { context ->
+                context.getBean(AuditEventSink::class.java).assert().isInstanceOf(KafkaAuditEventSink::class.java)
             }
     }
 

--- a/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfigurationTest.kt
+++ b/cosec-spring-boot-starter/src/test/kotlin/me/ahoo/cosec/spring/boot/starter/audit/kafka/CoSecKafkaAuditAutoConfigurationTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosec.spring.boot.starter.audit.kafka
+
+import io.mockk.mockk
+import me.ahoo.cosec.api.audit.AuditEventSink
+import me.ahoo.cosec.audit.LoggingAuditEventSink
+import me.ahoo.cosec.kafka.KafkaAuditEventSink
+import me.ahoo.cosec.spring.boot.starter.audit.AutoConfiguredAuthorizationTestConfiguration
+import me.ahoo.cosec.spring.boot.starter.audit.CoSecAuditAutoConfiguration
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.kafka.core.KafkaTemplate
+import java.util.function.Supplier
+
+class CoSecKafkaAuditAutoConfigurationTest {
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                CoSecKafkaAuditAutoConfiguration::class.java,
+                CoSecAuditAutoConfiguration::class.java,
+            ),
+        )
+        .withUserConfiguration(AutoConfiguredAuthorizationTestConfiguration::class.java)
+
+    @Test
+    fun kafkaSinkWinsByDefault() {
+        contextRunner
+            .withConfiguration(AutoConfigurations.of(KafkaAutoConfiguration::class.java))
+            .run { context ->
+                context.getBean(AuditEventSink::class.java).assert().isInstanceOf(KafkaAuditEventSink::class.java)
+                context.getBeansOfType(LoggingAuditEventSink::class.java).assert().isEmpty()
+            }
+    }
+
+    @Test
+    fun disabledKafkaFallsBackToLogging() {
+        contextRunner
+            .withKafkaTemplate()
+            .withPropertyValues("cosec.audit.kafka.enabled=false")
+            .run { context ->
+                context.getBean(AuditEventSink::class.java).assert().isInstanceOf(LoggingAuditEventSink::class.java)
+            }
+    }
+
+    @Test
+    fun missingKafkaFallsBackToLogging() {
+        contextRunner.run { context ->
+            context.getBean(AuditEventSink::class.java).assert().isInstanceOf(LoggingAuditEventSink::class.java)
+        }
+    }
+
+    @Test
+    fun customSinkWins() {
+        val customSink = mockk<AuditEventSink>()
+        contextRunner
+            .withKafkaTemplate()
+            .withBean("customSink", AuditEventSink::class.java, Supplier { customSink })
+            .run { context ->
+                context.getBean(AuditEventSink::class.java).assert().isSameAs(customSink)
+            }
+    }
+
+    @Test
+    fun auditOffLoadsNoSink() {
+        contextRunner
+            .withKafkaTemplate()
+            .withPropertyValues("cosec.audit.enabled=false")
+            .run { context ->
+                context.getBeansOfType(AuditEventSink::class.java).assert().isEmpty()
+            }
+    }
+
+    private fun ApplicationContextRunner.withKafkaTemplate(): ApplicationContextRunner {
+        return withBean(
+            "kafkaTemplate",
+            KafkaTemplate::class.java,
+            Supplier { mockk<KafkaTemplate<String, String>>(relaxed = true) },
+        )
+    }
+}

--- a/wiki/getting-started/configuration.md
+++ b/wiki/getting-started/configuration.md
@@ -165,7 +165,9 @@ aside automatically (the decorator only wraps the auto-configured
 The `kafka-support` feature replaces the logging sink with an asynchronous
 `KafkaAuditEventSink`. Each record uses a JSON `[tenantId, principalId]` tuple
 as its key and a single-line `AuditEvent` JSON value. Configure the broker with
-`spring.kafka.*`; CoSec does not create the topic.
+`spring.kafka.*`; CoSec does not create the topic. To keep authorization
+non-blocking during an outage, the sink queues at most 1024 events and drops
+new events with a warning when that queue is full.
 
 ### Gateway Properties (`cosec.authorization.gateway.*`)
 

--- a/wiki/getting-started/configuration.md
+++ b/wiki/getting-started/configuration.md
@@ -163,9 +163,9 @@ aside automatically (the decorator only wraps the auto-configured
 `cosecAuthorization` bean).
 
 The `kafka-support` feature replaces the logging sink with an asynchronous
-`KafkaAuditEventSink`. Each record uses `tenantId:principalId` as its key and a
-single-line `AuditEvent` JSON value. Configure the broker with `spring.kafka.*`;
-CoSec does not create the topic.
+`KafkaAuditEventSink`. Each record uses a JSON `[tenantId, principalId]` tuple
+as its key and a single-line `AuditEvent` JSON value. Configure the broker with
+`spring.kafka.*`; CoSec does not create the topic.
 
 ### Gateway Properties (`cosec.authorization.gateway.*`)
 

--- a/wiki/getting-started/configuration.md
+++ b/wiki/getting-started/configuration.md
@@ -147,6 +147,8 @@ Controls audit logging of authorization decisions.
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `cosec.audit.enabled` | `Boolean` | `true` | Whether to audit authorization decisions. |
+| `cosec.audit.kafka.enabled` | `Boolean` | `true` | Use Kafka instead of the logging sink when `kafka-support` is present. |
+| `cosec.audit.kafka.topic` | `String` | `cosec-audit` | Kafka topic for audit events. |
 
 Defined in `AuditProperties` ([cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt:26](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt#L26)).
 
@@ -159,6 +161,11 @@ own `AuditEventSink` bean to ship events to Kafka/Elasticsearch/your database.
 If you replace the default `Authorization` bean with your own, audit wiring steps
 aside automatically (the decorator only wraps the auto-configured
 `cosecAuthorization` bean).
+
+The `kafka-support` feature replaces the logging sink with an asynchronous
+`KafkaAuditEventSink`. Each record uses `tenantId:principalId` as its key and a
+single-line `AuditEvent` JSON value. Configure the broker with `spring.kafka.*`;
+CoSec does not create the topic.
 
 ### Gateway Properties (`cosec.authorization.gateway.*`)
 
@@ -227,6 +234,10 @@ sequenceDiagram
 ## Example Application.yaml
 
 ```yaml
+spring:
+  kafka:
+    bootstrap-servers: "localhost:9092"
+
 cosec:
   # Master switch
   enabled: true
@@ -269,6 +280,13 @@ cosec:
     gateway:
       enabled: true
 
+  # Audit
+  audit:
+    enabled: true
+    kafka:
+      enabled: true
+      topic: "cosec-audit"
+
   # IP Geolocation
   ip2region:
     enabled: true
@@ -292,6 +310,7 @@ flowchart LR
     STARTER --> IP["ip2region-support"]
     STARTER --> OT["opentelemetry-support"]
     STARTER --> OAPI["openapi-support"]
+    STARTER --> K["kafka-support"]
 
     style STARTER fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
     style W fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
@@ -302,6 +321,7 @@ flowchart LR
     style IP fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
     style OT fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
     style OAPI fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    style K fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
 
 ```
 
@@ -315,6 +335,7 @@ flowchart LR
 | `ip2region-support` | `cosec-ip2region` | ip2region library |
 | `opentelemetry-support` | `cosec-opentelemetry` | OpenTelemetry |
 | `openapi-support` | `cosec-openapi` | SpringDoc OpenAPI |
+| `kafka-support` | `cosec-kafka` | Spring for Apache Kafka |
 
 Feature variants are declared in `build.gradle.kts` ([cosec-spring-boot-starter/build.gradle.kts:18](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/build.gradle.kts#L18)).
 

--- a/wiki/getting-started/configuration.md
+++ b/wiki/getting-started/configuration.md
@@ -167,7 +167,8 @@ The `kafka-support` feature replaces the logging sink with an asynchronous
 as its key and a single-line `AuditEvent` JSON value. Configure the broker with
 `spring.kafka.*`; CoSec does not create the topic. To keep authorization
 non-blocking during an outage, the sink queues at most 1024 events and drops
-new events with a warning when that queue is full.
+new events with a warning when that queue is full. During shutdown it waits up
+to 10 seconds for accepted events to drain before forcing the scheduler closed.
 
 ### Gateway Properties (`cosec.authorization.gateway.*`)
 

--- a/wiki/getting-started/configuration.md
+++ b/wiki/getting-started/configuration.md
@@ -167,8 +167,9 @@ The `kafka-support` feature replaces the logging sink with an asynchronous
 as its key and a single-line `AuditEvent` JSON value. Configure the broker with
 `spring.kafka.*`; CoSec does not create the topic. To keep authorization
 non-blocking during an outage, the sink queues at most 1024 events and drops
-new events with a warning when that queue is full. During shutdown it waits up
-to 10 seconds for accepted events to drain before forcing the scheduler closed.
+new events when that queue is full, logging once until queue processing resumes.
+During shutdown it waits up to 10 seconds for accepted events to drain before
+forcing the scheduler closed.
 
 ### Gateway Properties (`cosec.authorization.gateway.*`)
 

--- a/wiki/getting-started/quick-start.md
+++ b/wiki/getting-started/quick-start.md
@@ -37,6 +37,8 @@ dependencies {
     // requireCapability("me.ahoo.cosec:gateway-support")
     // Or for caching (Redis):
     // requireCapability("me.ahoo.cosec:cache-support")
+    // Or for Kafka auditing:
+    // requireCapability("me.ahoo.cosec:kafka-support")
 }
 ```
 

--- a/wiki/zh/getting-started/configuration.md
+++ b/wiki/zh/getting-started/configuration.md
@@ -161,8 +161,8 @@ flowchart TD
 bean）。
 
 `kafka-support` 功能会使用异步 `KafkaAuditEventSink` 替代日志 Sink。每条消息以
-`tenantId:principalId` 为 Key，以单行 `AuditEvent` JSON 为 Value。Broker 通过
-`spring.kafka.*` 配置；CoSec 不负责创建 Topic。
+JSON `[tenantId, principalId]` 二元组为 Key，以单行 `AuditEvent` JSON 为 Value。
+Broker 通过 `spring.kafka.*` 配置；CoSec 不负责创建 Topic。
 
 ### 网关属性（`cosec.authorization.gateway.*`）
 

--- a/wiki/zh/getting-started/configuration.md
+++ b/wiki/zh/getting-started/configuration.md
@@ -147,6 +147,8 @@ flowchart TD
 | 属性 | 类型 | 默认值 | 描述 |
 |------|------|--------|------|
 | `cosec.audit.enabled` | `Boolean` | `true` | 是否审计授权决策。 |
+| `cosec.audit.kafka.enabled` | `Boolean` | `true` | 存在 `kafka-support` 时使用 Kafka 替代日志 Sink。 |
+| `cosec.audit.kafka.topic` | `String` | `cosec-audit` | 审计事件发送到的 Kafka Topic。 |
 
 定义在 `AuditProperties`（[cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt:26](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/AuditProperties.kt#L26)）中。
 
@@ -157,6 +159,10 @@ flowchart TD
 `AuditEventSink` bean 可将事件接入 Kafka/ES/数据库。若你用自定义 bean 替换了默认的
 `Authorization`，审计装配会自动让位（装饰器仅包裹自动配置的 `cosecAuthorization`
 bean）。
+
+`kafka-support` 功能会使用异步 `KafkaAuditEventSink` 替代日志 Sink。每条消息以
+`tenantId:principalId` 为 Key，以单行 `AuditEvent` JSON 为 Value。Broker 通过
+`spring.kafka.*` 配置；CoSec 不负责创建 Topic。
 
 ### 网关属性（`cosec.authorization.gateway.*`）
 
@@ -225,6 +231,10 @@ sequenceDiagram
 ## 示例 Application.yaml
 
 ```yaml
+spring:
+  kafka:
+    bootstrap-servers: "localhost:9092"
+
 cosec:
   # 主开关
   enabled: true
@@ -267,6 +277,13 @@ cosec:
     gateway:
       enabled: true
 
+  # 审计
+  audit:
+    enabled: true
+    kafka:
+      enabled: true
+      topic: "cosec-audit"
+
   # IP 地理定位
   ip2region:
     enabled: true
@@ -290,6 +307,7 @@ flowchart LR
     STARTER --> IP["ip2region-support"]
     STARTER --> OT["opentelemetry-support"]
     STARTER --> OAPI["openapi-support"]
+    STARTER --> K["kafka-support"]
 
     style STARTER fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
     style W fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
@@ -300,6 +318,7 @@ flowchart LR
     style IP fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
     style OT fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
     style OAPI fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    style K fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
 
 ```
 
@@ -313,6 +332,7 @@ flowchart LR
 | `ip2region-support` | `cosec-ip2region` | ip2region 库 |
 | `opentelemetry-support` | `cosec-opentelemetry` | OpenTelemetry |
 | `openapi-support` | `cosec-openapi` | SpringDoc OpenAPI |
+| `kafka-support` | `cosec-kafka` | Spring for Apache Kafka |
 
 功能变体在 `build.gradle.kts`（[cosec-spring-boot-starter/build.gradle.kts:18](https://github.com/Ahoo-Wang/CoSec/blob/main/cosec-spring-boot-starter/build.gradle.kts#L18)）中声明。
 

--- a/wiki/zh/getting-started/configuration.md
+++ b/wiki/zh/getting-started/configuration.md
@@ -163,7 +163,8 @@ bean）。
 `kafka-support` 功能会使用异步 `KafkaAuditEventSink` 替代日志 Sink。每条消息以
 JSON `[tenantId, principalId]` 二元组为 Key，以单行 `AuditEvent` JSON 为 Value。
 Broker 通过 `spring.kafka.*` 配置；CoSec 不负责创建 Topic。为避免 Kafka 故障时阻塞
-授权，Sink 最多排队 1024 个事件；队列已满时丢弃新事件并记录警告。
+授权，Sink 最多排队 1024 个事件；队列已满时丢弃新事件并记录警告。应用关闭时最多
+等待 10 秒排空已接受事件，之后强制关闭调度器。
 
 ### 网关属性（`cosec.authorization.gateway.*`）
 

--- a/wiki/zh/getting-started/configuration.md
+++ b/wiki/zh/getting-started/configuration.md
@@ -163,8 +163,8 @@ bean）。
 `kafka-support` 功能会使用异步 `KafkaAuditEventSink` 替代日志 Sink。每条消息以
 JSON `[tenantId, principalId]` 二元组为 Key，以单行 `AuditEvent` JSON 为 Value。
 Broker 通过 `spring.kafka.*` 配置；CoSec 不负责创建 Topic。为避免 Kafka 故障时阻塞
-授权，Sink 最多排队 1024 个事件；队列已满时丢弃新事件并记录警告。应用关闭时最多
-等待 10 秒排空已接受事件，之后强制关闭调度器。
+授权，Sink 最多排队 1024 个事件；队列已满时丢弃新事件，在队列恢复处理前仅记录
+一次警告。应用关闭时最多等待 10 秒排空已接受事件，之后强制关闭调度器。
 
 ### 网关属性（`cosec.authorization.gateway.*`）
 

--- a/wiki/zh/getting-started/configuration.md
+++ b/wiki/zh/getting-started/configuration.md
@@ -162,7 +162,8 @@ bean）。
 
 `kafka-support` 功能会使用异步 `KafkaAuditEventSink` 替代日志 Sink。每条消息以
 JSON `[tenantId, principalId]` 二元组为 Key，以单行 `AuditEvent` JSON 为 Value。
-Broker 通过 `spring.kafka.*` 配置；CoSec 不负责创建 Topic。
+Broker 通过 `spring.kafka.*` 配置；CoSec 不负责创建 Topic。为避免 Kafka 故障时阻塞
+授权，Sink 最多排队 1024 个事件；队列已满时丢弃新事件并记录警告。
 
 ### 网关属性（`cosec.authorization.gateway.*`）
 

--- a/wiki/zh/getting-started/quick-start.md
+++ b/wiki/zh/getting-started/quick-start.md
@@ -37,6 +37,8 @@ dependencies {
     // requireCapability("me.ahoo.cosec:gateway-support")
     // 或者用于缓存（Redis）：
     // requireCapability("me.ahoo.cosec:cache-support")
+    // 或者用于 Kafka 审计：
+    // requireCapability("me.ahoo.cosec:kafka-support")
 }
 ```
 


### PR DESCRIPTION
## Summary

- add a `cosec-kafka` module with an asynchronous JSON `KafkaAuditEventSink`
- add the optional `kafka-support` starter capability and conditional auto-configuration
- document Kafka audit configuration in English and Chinese

## Why

Applications currently need to implement their own `AuditEventSink` to publish authorization audits to Kafka. This adds an official non-blocking sink while preserving the existing logging fallback.

## Impact

Users opt in with the `me.ahoo.cosec:kafka-support` capability and configure brokers through `spring.kafka.*`. Events use JSON `[tenantId, principalId]` as the record key and `AuditEvent` JSON as the value. CoSec does not create the topic.

## Validation

- `./gradlew :cosec-kafka:test :cosec-spring-boot-starter:test detekt`
- `./gradlew build`