### PR TITLE
feat: support Kafka audit logs in gateway server

### DIFF
--- a/cosec-gateway-server/build.gradle.kts
+++ b/cosec-gateway-server/build.gradle.kts
@@ -60,7 +60,11 @@ dependencies {
     implementation(project(":cosec-webflux"))
     implementation(project(":cosec-gateway"))
     implementation(project(":cosec-opentelemetry"))
-    implementation(project(":cosec-spring-boot-starter"))
+    implementation(project(":cosec-spring-boot-starter")) {
+        capabilities {
+            requireCapability("me.ahoo.cosec:kafka-support")
+        }
+    }
     implementation(project(":cosec-ip2region"))
     implementation("me.ahoo.cocache:cocache-spring-boot-starter")
     implementation("com.github.ben-manes.caffeine:caffeine")

--- a/cosec-gateway-server/src/dist/config/application.yaml
+++ b/cosec-gateway-server/src/dist/config/application.yaml
@@ -9,6 +9,9 @@ spring:
       whitelabel:
         enabled: false
 cosec:
+  audit:
+    kafka:
+      enabled: false
   authentication:
     enabled: false
   authorization:

--- a/cosec-gateway-server/src/main/resources/application.yaml
+++ b/cosec-gateway-server/src/main/resources/application.yaml
@@ -36,6 +36,9 @@ spring:
               filters:
                 - StripPrefix=1
 cosec:
+  audit:
+    kafka:
+      enabled: false
   authentication:
     enabled: false
   jwt:

--- a/k8s/cosec-gateway-config.yaml
+++ b/k8s/cosec-gateway-config.yaml
@@ -42,6 +42,9 @@ data:
                   filters:
                     - StripPrefix=1
     cosec:
+      audit:
+        kafka:
+          enabled: false
       authentication:
         enabled: false
       jwt:


### PR DESCRIPTION
## Summary

- select the existing `kafka-support` capability for `cosec-gateway-server`
- keep Kafka auditing disabled by default in development and distribution configuration

## Why

This makes Kafka audit publishing available to the standalone gateway without changing its default runtime behavior. When disabled, the existing logging audit sink remains active.

## Impact

Operators can enable Kafka auditing with `cosec.audit.kafka.enabled=true` and configure the broker through `spring.kafka.*`.

## Validation

- `./gradlew :cosec-gateway-server:test :cosec-gateway-server:detekt`
- `./gradlew :cosec-spring-boot-starter:test --tests "me.ahoo.cosec.spring.boot.starter.audit.kafka.CoSecKafkaAuditAutoConfigurationTest"`
- verified the gateway runtime classpath includes `cosec-kafka`, `spring-kafka`, and `kafka-clients`