### PR TITLE
docs(skills): streamline CoSec guidance

### DIFF
--- a/skills/cosec-custom-matcher/SKILL.md
+++ b/skills/cosec-custom-matcher/SKILL.md
@@ -1,296 +1,102 @@
 ---
 name: cosec-custom-matcher
-description: "Use when extending CoSec policy matching with custom ActionMatcher or ConditionMatcher implementations, condition types, matcher factories, ServiceLoader SPI registration, or Spring bean matcher registration."
+description: Extend CoSec with custom ActionMatcher or ConditionMatcher implementations and register their factories through ServiceLoader or Spring. Do not use for policies that built-in matchers already express.
 ---
 
-# CoSec Custom Matcher Development
+# CoSec Custom Matchers
 
-This skill helps you create custom `ActionMatcher` and `ConditionMatcher` implementations to extend CoSec's policy evaluation logic. CoSec uses Java SPI (ServiceLoader) to discover matcher factories.
+Add a matcher only after confirming that the built-ins cannot express the rule. Prefer composing `path`, `bool`, part matchers, or the local/Redis rate limiters over new code.
 
-## Architecture Overview
+## Extension contract
 
-Policy matching has two sides:
-- **ActionMatcher** — determines if a request's action (path + method) matches a policy pattern
-- **ConditionMatcher** — determines if contextual conditions are met (user attributes, request properties, etc.)
+- `ActionMatcher` and `ConditionMatcher` live in `cosec-api` and extend `RequestMatcher`.
+- Their factory interfaces and providers live in `cosec-core` under `me.ahoo.cosec.policy.action` and `me.ahoo.cosec.policy.condition`.
+- A factory's `type` is the object key used in policy JSON. It must not collide with another factory; later registration replaces the existing entry.
+- Do not change the SPI interfaces to add a matcher. Implement them and register the factory.
+- Keep matching synchronous and side-effect free unless the matcher intentionally enforces a stateful control such as rate limiting.
 
-Both extend `RequestMatcher`. The matcher interfaces live in `cosec-api` (`me.ahoo.cosec.api.policy`); the factory interfaces live in `cosec-core` (`me.ahoo.cosec.policy.action` / `me.ahoo.cosec.policy.condition`), and factory implementations are discovered via Java SPI (ServiceLoader).
+Before editing, inspect the target CoSec version's interfaces and the nearest built-in matcher. In a CoSec checkout, the authoritative files are:
 
-```
-Policy
-├── condition: ConditionMatcher (policy-level gate)
-└── statements[]
-    ├── Statement (effect: DENY)
-    │   ├── action: ActionMatcher
-    │   └── condition: ConditionMatcher
-    └── Statement (effect: ALLOW)
-        ├── action: ActionMatcher
-        └── condition: ConditionMatcher
-```
+- `cosec-api/src/main/kotlin/me/ahoo/cosec/api/principal/RequestMatcher.kt`
+- `cosec-core/src/main/kotlin/me/ahoo/cosec/policy/action/`
+- `cosec-core/src/main/kotlin/me/ahoo/cosec/policy/condition/`
 
-## Creating a Custom ConditionMatcher
+## Minimal condition matcher
 
-### Step 1: Implement the ConditionMatcher
+Use `AbstractConditionMatcher` when `negate` support is desirable. Parse and validate configuration once during construction, not on every request.
 
 ```kotlin
-package com.example.cosec.condition
+class PremiumUserConditionMatcher(configuration: Configuration) :
+    AbstractConditionMatcher(PremiumUserConditionMatcherFactory.TYPE, configuration) {
 
-import me.ahoo.cosec.api.context.SecurityContext
-import me.ahoo.cosec.api.context.request.Request
-import me.ahoo.cosec.api.policy.ConditionMatcher
-import me.ahoo.cosec.api.configuration.Configuration
+    private val requiredTier = configuration.getRequired("tier").asString()
 
-class PremiumUserConditionMatcher(
-    override val configuration: Configuration
-) : ConditionMatcher {
-
-    override val type: String = "premiumUser"
-
-    override fun match(request: Request, securityContext: SecurityContext): Boolean {
-        val isPremium = securityContext.principal.attributes["premium"]
-        return isPremium == "true"
+    override fun internalMatch(request: Request, securityContext: SecurityContext): Boolean {
+        val tier = securityContext.principal.attributes["tier"]?.toString()
+        return tier == requiredTier
     }
 }
-```
-
-Key points:
-- `type` — unique string identifier used in policy JSON
-- `configuration` — arbitrary key-value config passed from the policy JSON
-- `match()` — return `true` if the condition is satisfied. Throwing here fails the evaluation, so prefer returning `false` for non-matches and reserve exceptions for genuine misconfiguration (the built-in rate limiter, for example, throws to signal TOO_MANY_REQUESTS)
-
-### Step 2: Implement the Factory
-
-```kotlin
-package com.example.cosec.condition
-
-import me.ahoo.cosec.api.configuration.Configuration
-import me.ahoo.cosec.api.policy.ConditionMatcher
-import me.ahoo.cosec.policy.condition.ConditionMatcherFactory
 
 class PremiumUserConditionMatcherFactory : ConditionMatcherFactory {
-
-    override val type: String = "premiumUser"
-
-    override fun create(configuration: Configuration): ConditionMatcher {
-        return PremiumUserConditionMatcher(configuration)
+    companion object {
+        const val TYPE = "premiumUser"
     }
+
+    override val type: String = TYPE
+
+    override fun create(configuration: Configuration): ConditionMatcher =
+        PremiumUserConditionMatcher(configuration)
 }
 ```
 
-### Step 3: Register via SPI
+Register it for non-Spring and Spring environments with:
 
-Create file: `src/main/resources/META-INF/services/me.ahoo.cosec.policy.condition.ConditionMatcherFactory`
-
+```text
+# src/main/resources/META-INF/services/me.ahoo.cosec.policy.condition.ConditionMatcherFactory
+com.example.cosec.PremiumUserConditionMatcherFactory
 ```
-com.example.cosec.condition.PremiumUserConditionMatcherFactory
-```
-
-### Step 4: Use in Policy JSON
 
 ```json
 {
-  "name": "PremiumEndpoints",
   "action": "/api/premium/**",
   "condition": {
-    "premiumUser": {}
+    "premiumUser": { "tier": "gold" }
   }
 }
 ```
 
-With configuration:
-```json
-{
-  "name": "TieredAccess",
-  "action": "/api/**",
-  "condition": {
-    "premiumUser": {
-      "minTier": "gold"
-    }
-  }
-}
+For an action matcher, use the same pattern with `AbstractActionMatcher`, `ActionMatcherFactory`, and:
+
+```text
+src/main/resources/META-INF/services/me.ahoo.cosec.policy.action.ActionMatcherFactory
 ```
 
-Access configuration in the matcher:
-```kotlin
-val minTier = configuration.getRequired("minTier").asString()
-```
+## Spring registration
 
-## Creating a Custom ActionMatcher
-
-### Step 1: Implement the ActionMatcher
+When a factory needs Spring-managed dependencies, expose it as a bean instead of adding a service file:
 
 ```kotlin
-package com.example.cosec.action
-
-import me.ahoo.cosec.api.context.SecurityContext
-import me.ahoo.cosec.api.context.request.Request
-import me.ahoo.cosec.api.policy.ActionMatcher
-import me.ahoo.cosec.api.configuration.Configuration
-
-class HttpMethodActionMatcher(
-    override val configuration: Configuration
-) : ActionMatcher {
-
-    override val type: String = "httpMethod"
-
-    private val allowedMethods: Set<String> = configuration.getRequired("methods")
-        .asString()
-        .split(",")
-        .map { it.trim().uppercase() }
-        .toSet()
-
-    override fun match(request: Request, securityContext: SecurityContext): Boolean {
-        return request.method.uppercase() in allowedMethods
-    }
-}
+@Bean
+fun premiumUserConditionMatcherFactory(): ConditionMatcherFactory =
+    PremiumUserConditionMatcherFactory()
 ```
 
-### Step 2: Implement the Factory
+`MatcherFactoryRegister` registers all action and condition factory beans at startup. Do not register the same type through both mechanisms unless replacement is intentional.
 
-```kotlin
-package com.example.cosec.action
+## Useful API surface
 
-import me.ahoo.cosec.api.configuration.Configuration
-import me.ahoo.cosec.api.policy.ActionMatcher
-import me.ahoo.cosec.policy.action.ActionMatcherFactory
+Read configuration through `get`/`getRequired` followed by `asString`, `asBoolean`, `asInt`, `asLong`, `asDouble`, `asList`, or `asMap`.
 
-class HttpMethodActionMatcherFactory : ActionMatcherFactory {
+Request matching commonly uses `path`, `method`, `remoteIp`, `origin`, `referer`, `appId`, `spaceId`, `deviceId`, `requestId`, headers, queries, cookies, and request attributes. Context matching commonly uses principal ID/authentication/roles/policies/attributes, tenant ID, and context attributes. Inspect the target interfaces rather than assuming fields from another CoSec version.
 
-    override val type: String = "httpMethod"
+## Existing type names
 
-    override fun create(configuration: Configuration): ActionMatcher {
-        return HttpMethodActionMatcher(configuration)
-    }
-}
-```
+Do not replace these unless the user explicitly wants an override:
 
-### Step 3: Register via SPI
+- Actions: `all`, `path`, `composite`
+- Conditions: `all`, `authenticated`, `inRole`, `inTenant`, `eq`, `contains`, `startsWith`, `endsWith`, `in`, `regular`, `path`, `bool`, `spel`, `ognl`, `rateLimiter`, `groupedRateLimiter`
+- With Redis cache support: `redisRateLimiter`, `redisGroupedRateLimiter`
 
-Create file: `src/main/resources/META-INF/services/me.ahoo.cosec.policy.action.ActionMatcherFactory`
+## Verification
 
-```
-com.example.cosec.action.HttpMethodActionMatcherFactory
-```
-
-### Step 4: Use in Policy JSON
-
-```json
-{
-  "name": "ReadOnlyAccess",
-  "action": {
-    "httpMethod": {
-      "methods": "GET,HEAD,OPTIONS"
-    }
-  }
-}
-```
-
-## Accessing Configuration Values
-
-The `Configuration` interface is a tree of typed nodes — there are no convenience accessors like `getRequiredString`; chain a `get`/`getRequired` with an `as*` conversion:
-
-```kotlin
-// Required (getRequired throws IllegalArgumentException if missing)
-val value: String = configuration.getRequired("key").asString()
-val count: Int = configuration.getRequired("key").asInt()
-
-// Optional with default
-val value: String = configuration.get("key")?.asString() ?: "default"
-
-// Nested configuration (getRequired returns a Configuration directly)
-val nested: Configuration = configuration.getRequired("nested")
-
-// Collections
-val list: List<String> = configuration.getRequired("tags").asStringList()
-val map: Map<String, String> = configuration.getRequired("labels").asStringMap()
-
-// Existence check
-if (configuration.has("key")) { ... }
-```
-
-## Accessing Request and Context Data
-
-### Request properties
-```kotlin
-request.path           // URL path
-request.method         // HTTP method
-request.remoteIp       // client IP
-request.origin         // Origin as URI; request.origin.host for the host part
-request.referer        // Referer as URI; request.referer.host for the host part
-request.appId          // application ID
-request.spaceId        // space ID
-request.deviceId       // device ID
-request.requestId      // request ID
-request.getHeader("X-Custom")    // any header
-request.getQuery("param")        // query parameter
-request.getCookieValue("name")   // cookie value
-```
-
-### SecurityContext properties
-```kotlin
-securityContext.principal                    // CoSecPrincipal
-securityContext.principal.id                 // user ID
-securityContext.principal.authenticated      // boolean
-securityContext.principal.anonymous          // boolean
-securityContext.principal.roles              // Set<RoleId> (RoleCapable, RoleId = String)
-securityContext.principal.policies           // Set<String> of attached policy IDs (PolicyCapable)
-securityContext.principal.attributes         // Map<String, Any>
-securityContext.tenant                       // Tenant (use .tenantId)
-securityContext.attributes                   // MutableMap<String, Any> (carries path variables etc.)
-```
-
-## Built-in ConditionMatcher Types Reference
-
-For reference, here are all built-in types:
-
-| Type | Description | Key Config |
-|------|-------------|------------|
-| `all` | Match all (the default when `condition` is omitted) | — |
-| `authenticated` | User must be logged in | — |
-| `inRole` | User must have role | `value`: role name |
-| `inTenant` | Must be from tenant type | `value`: `default` / `user` / `platform` |
-| `eq` | Exact match | `part`, `value` |
-| `contains` | Substring match | `part`, `value` |
-| `startsWith` | Prefix match | `part`, `value` |
-| `endsWith` | Suffix match | `part`, `value` |
-| `in` | Value in list | `part`, `value`: array |
-| `regular` | Regex match | `part`, `pattern`, `negate` |
-| `path` | Path pattern match | `part`, `pattern`, `options` |
-| `bool` | Boolean logic | `and`: array, `or`: array |
-| `spel` | Spring Expression | `expression` |
-| `ognl` | OGNL expression | `expression` |
-| `rateLimiter` | Rate limiting | `permitsPerSecond` |
-| `groupedRateLimiter` | Grouped rate limit | `part`, `permitsPerSecond`, `expireAfterAccessSecond` |
-
-`negate: true` is accepted by **every** condition matcher above (it is handled centrally in `AbstractConditionMatcher`, not just by `regular`); `rateLimiter` is the only one without it.
-
-Avoid redefining these type names — SPI registration and Spring registration both key off the `type` string, and a duplicate overrides the built-in factory.
-
-## Built-in ActionMatcher Types Reference
-
-| Type | Description | Key Config |
-|------|-------------|------------|
-| `path` | URL path matching | `pattern`, `method`, `options` |
-| `all` | Wildcard | `method` (optional) |
-| `composite` | OR combination | array of matchers |
-
-## Spring Registration (Alternative to SPI)
-
-You can also register matcher factories as Spring beans. The `MatcherFactoryRegister` lifecycle bean picks up every `ConditionMatcherFactory` / `ActionMatcherFactory` bean from the `ApplicationContext` at startup:
-
-```kotlin
-@Configuration
-class CustomMatcherConfig {
-
-    @Bean
-    fun premiumUserConditionMatcherFactory(): ConditionMatcherFactory {
-        return PremiumUserConditionMatcherFactory()
-    }
-
-    @Bean
-    fun httpMethodActionMatcherFactory(): ActionMatcherFactory {
-        return HttpMethodActionMatcherFactory()
-    }
-}
-```
-
-This approach is simpler when your matcher needs Spring dependencies (e.g., a database or external service).
+Add one focused test that creates the matcher through its factory and checks a match and non-match. If registration changed, also deserialize one policy using the custom type so a missing service entry or Spring bean fails the test. Run the narrow module test and the repository's static analysis command.

--- a/skills/cosec-custom-matcher/agents/openai.yaml
+++ b/skills/cosec-custom-matcher/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "CoSec Custom Matchers"
   short_description: "Build CoSec matcher extensions"
-  default_prompt: "Use $cosec-custom-matcher to implement a custom CoSec condition matcher and register it with SPI."
+  default_prompt: "Use $cosec-custom-matcher to implement and register a custom CoSec action or condition matcher."

--- a/skills/cosec-integration/SKILL.md
+++ b/skills/cosec-integration/SKILL.md
@@ -1,259 +1,102 @@
 ---
 name: cosec-integration
-description: "Use when adding CoSec to a Spring Boot application, choosing WebFlux/WebMVC/Gateway modules, configuring JWT authentication, authorization filters, local policies, Redis policy caching, social login, IP enrichment, OpenAPI, or OpenTelemetry integration."
+description: Integrate CoSec into Spring Boot by selecting WebFlux, WebMVC, or Gateway support and configuring JWT, local policies, Redis, auditing, or optional integrations. Do not use for policy-only authoring or diagnosis.
 ---
 
-# CoSec Integration Guide
+# CoSec Spring Boot Integration
 
-This skill guides you through integrating CoSec into a Spring Boot application. CoSec is a reactive, multi-tenant RBAC + Policy-based security framework built on Spring Boot and Project Reactor.
+Make the smallest integration that fits the target application. Preserve its build tool, dependency-management style, HTTP stack, configuration format, and existing security boundaries.
 
-## Step 1: Add Dependencies
+## Inspect first
 
-CoSec modules are published to Maven Central under the `me.ahoo.cosec` group. Use the BOM for version management.
+Determine:
 
-### Gradle (Kotlin DSL)
+- Spring WebFlux, Spring MVC, or Spring Cloud Gateway; add exactly the matching CoSec transport.
+- The CoSec version already managed by a BOM, version catalog, parent, or lockfile. Never copy a version from this skill.
+- Whether policies are local-only or must initialize a shared repository.
+- Whether Redis, OAuth, IP enrichment, tracing, OpenAPI, Kafka, or token revocation is actually required.
+
+The starter already brings `cosec-core` and `cosec-jwt`. Prefer its Gradle feature capabilities because they include the integration and its runtime dependencies:
+
+| Need | Starter capability | CoSec module |
+|---|---|---|
+| Spring MVC | `webmvc-support` | `cosec-webmvc` |
+| Spring WebFlux | `webflux-support` | `cosec-webflux` |
+| Spring Cloud Gateway | `gateway-support` | `cosec-gateway` |
+| Social OAuth | `oauth-support` | `cosec-social` |
+| Redis cache, revocation, distributed limiters | `cache-support` | `cosec-cocache` |
+| IP region | `ip2region-support` | `cosec-ip2region` |
+| OpenTelemetry | `opentelemetry-support` | `cosec-opentelemetry` |
+| OpenAPI | `openapi-support` | `cosec-openapi` |
+| Kafka audit sink | `kafka-support` | `cosec-kafka` |
+
+For Gradle, select a capability on the starter dependency:
 
 ```kotlin
-// gradle/libs.versions.toml
-[versions]
-cosec = "4.9.0"  // check latest at https://central.sonatype.com/artifact/me.ahoo.cosec/cosec-bom
-
-[libraries]
-cosec-bom = { module = "me.ahoo.cosec:cosec-bom", version.ref = "cosec" }
-cosec-spring-boot-starter = { module = "me.ahoo.cosec:cosec-spring-boot-starter" }
-cosec-webflux = { module = "me.ahoo.cosec:cosec-webflux" }
-cosec-webmvc = { module = "me.ahoo.cosec:cosec-webmvc" }
-cosec-gateway = { module = "me.ahoo.cosec:cosec-gateway" }
-cosec-jwt = { module = "me.ahoo.cosec:cosec-jwt" }
-cosec-cocache = { module = "me.ahoo.cosec:cosec-cocache" }
-cosec-social = { module = "me.ahoo.cosec:cosec-social" }
-cosec-ip2region = { module = "me.ahoo.cosec:cosec-ip2region" }
-cosec-opentelemetry = { module = "me.ahoo.cosec:cosec-opentelemetry" }
-cosec-openapi = { module = "me.ahoo.cosec:cosec-openapi" }
-```
-
-```kotlin
-// build.gradle.kts
-dependencies {
-    implementation(platform(libs.cosec.bom))
-    implementation(libs.cosec.spring.boot.starter)
-    implementation(libs.cosec.webflux)   // for WebFlux apps
-    // implementation(libs.cosec.webmvc)  // for Servlet apps
-    // implementation(libs.cosec.gateway) // for Spring Cloud Gateway
-    implementation(libs.cosec.jwt)       // JWT token handling
-    // implementation(libs.cosec.cocache) // Redis policy caching
+implementation(platform(libs.cosec.bom))
+implementation("me.ahoo.cosec:cosec-spring-boot-starter") {
+    capabilities {
+        requireCapability("me.ahoo.cosec:webflux-support")
+    }
 }
 ```
 
-### Maven
+Declare the starter again for each additional capability. The module column is a mapping, not a complete dependency set. With Maven or a build that cannot select Gradle variants, use the BOM, starter, one transport module, and mirror the selected feature's runtime dependencies. In the current build, cache support also needs `org.springframework.boot:spring-boot-data-redis` and `me.ahoo.cocache:cocache-spring-boot-starter`, OpenAPI support needs `org.springframework.boot:spring-boot-starter-actuator` and `org.springdoc:springdoc-openapi-starter-common`, and Kafka support needs `org.springframework.boot:spring-boot-starter-kafka`.
 
-```xml
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>me.ahoo.cosec</groupId>
-            <artifactId>cosec-bom</artifactId>
-            <version>4.9.0</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-
-<dependencies>
-    <dependency>
-        <groupId>me.ahoo.cosec</groupId>
-        <artifactId>cosec-spring-boot-starter</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>me.ahoo.cosec</groupId>
-        <artifactId>cosec-webflux</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>me.ahoo.cosec</groupId>
-        <artifactId>cosec-jwt</artifactId>
-    </dependency>
-</dependencies>
-```
-
-### Module Selection Guide
-
-| Use Case | Required Modules |
-|----------|-----------------|
-| Basic WebFlux app | `cosec-spring-boot-starter` + `cosec-webflux` |
-| Servlet/WebMVC app | `cosec-spring-boot-starter` + `cosec-webmvc` |
-| API Gateway | `cosec-spring-boot-starter` + `cosec-gateway` |
-| JWT authentication | add `cosec-jwt` |
-| Redis policy caching | add `cosec-cocache` |
-| Social OAuth login | add `cosec-social` |
-| IP geolocation conditions | add `cosec-ip2region` |
-| Authorization tracing | add `cosec-opentelemetry` |
-| OpenAPI/Swagger integration | add `cosec-openapi` |
-
-## Step 2: Configure application.yaml
+## Minimal configuration
 
 ```yaml
 cosec:
-  enabled: true                        # master switch (default: true)
-  authentication:
-    enabled: true                      # enable authentication (default: true)
-  authorization:
-    enabled: true                      # enable authorization (default: true)
-    local-policy:
-      enabled: true                    # load policies from local JSON files
-      locations: classpath:cosec-policy/*-policy.json
-      init-repository: true            # push local policies to repository on startup
-  jwt:
-    algorithm: hmac256                 # hmac256 (default), hmac384, hmac512
-    secret: your-256-bit-secret-key    # required for HMAC algorithms
-```
-
-### Property Reference
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `cosec.enabled` | `true` | Master enable/disable switch |
-| `cosec.authentication.enabled` | `true` | Enable/disable authentication |
-| `cosec.authorization.enabled` | `true` | Enable/disable authorization |
-| `cosec.authorization.local-policy.enabled` | `false` | Load policies from local JSON files |
-| `cosec.authorization.local-policy.locations` | `classpath:cosec-policy/*-policy.json` | Resource patterns for policy files |
-| `cosec.authorization.local-policy.init-repository` | `false` | Push local policies to repository on startup |
-| `cosec.authorization.local-policy.force-refresh` | `false` | Force-refresh repository policies on init |
-| `cosec.authorization.remote-ip.max-trusted-index` | `1` | Trusted proxy hops for X-Forwarded-For resolution; `0` ignores the header |
-| `cosec.jwt.enabled` | `true` | Enable JWT auto-configuration |
-| `cosec.jwt.algorithm` | `hmac256` | JWT algorithm (`hmac256`, `hmac384`, `hmac512` — RSA is not supported) |
-| `cosec.jwt.secret` | — | JWT secret key (required for HMAC algorithms) |
-| `cosec.jwt.token-validity.access` | `10m` | Access token time-to-live |
-| `cosec.jwt.token-validity.refresh` | `7d` | Refresh token time-to-live |
-| `cosec.jwt.token-revocation.enabled` | `false` | Reject revoked tokens (logout support; back the revocation store with `cosec-cocache` for distributed setups) |
-| `cosec.ip2region.enabled` | `true` | Enable IP geolocation (takes effect when `cosec-ip2region` is on the classpath) |
-| `cosec.openapi.enabled` | `true` | Enable OpenAPI integration (takes effect when `cosec-openapi` is on the classpath) |
-
-## Step 3: Create Policy Files
-
-Place policy JSON files in `src/main/resources/cosec-policy/`. Files must match the pattern `*-policy.json`.
-
-### Minimal Example — Public Health Endpoint
-
-```json
-{
-  "id": "(health-probe)",
-  "name": "Health Probe",
-  "type": "global",
-  "tenantId": "(platform)",
-  "statements": [
-    {
-      "name": "actuator",
-      "action": [
-        "/actuator/health",
-        "/actuator/health/readiness",
-        "/actuator/health/liveness"
-      ]
-    }
-  ]
-}
-```
-
-### Typical Example — API with Auth
-
-```json
-{
-  "id": "api-policy",
-  "name": "API Policy",
-  "type": "global",
-  "tenantId": "(platform)",
-  "statements": [
-    {
-      "name": "PublicEndpoints",
-      "action": ["/auth/login", "/auth/register"]
-    },
-    {
-      "name": "AuthenticatedApi",
-      "action": "/api/**",
-      "condition": { "authenticated": {} }
-    },
-    {
-      "name": "AdminEndpoints",
-      "action": "/admin/**",
-      "condition": { "inRole": { "value": "admin" } }
-    }
-  ]
-}
-```
-
-See the `cosec-policy-author` skill for full policy JSON reference.
-
-## Step 4: Spring Boot Application
-
-No special annotations or configuration classes needed. CoSec auto-configures everything based on classpath and properties.
-
-```kotlin
-@SpringBootApplication
-class MyApp
-
-fun main(args: Array<String>) {
-    runApplication<MyApp>(*args)
-}
-```
-
-The auto-configuration automatically registers:
-- `ReactiveAuthorizationFilter` (WebFlux) or `AuthorizationFilter` (WebMVC) or `AuthorizationGatewayFilter` (Gateway)
-- `SecurityContextParser` for extracting security context from requests
-- `SimpleAuthorization` for policy evaluation
-- `LocalPolicyLoader` / `LocalPolicyInitializer` for loading local policy files
-- JWT token converter and verifier (if `cosec-jwt` is on classpath)
-- Token revocation beans (`TokenStore` / `TokenRevoker` / `RevocableTokenVerifier`) — revocation takes effect only with `cosec.jwt.token-revocation.enabled=true` plus a Redis-backed store (`cosec-cocache`)
-- Request parsers for both reactive and servlet environments
-
-## Gateway Server Reference
-
-The `cosec-gateway-server` module is a complete reference implementation. Key configuration:
-
-```yaml
-# application.yaml
-cosec:
-  authentication:
-    enabled: false          # Gateway relies on token injection from upstream
   jwt:
     algorithm: hmac256
-    secret: ${COSEC_JWT_SECRET:change-me-in-production}
+    secret: ${COSEC_JWT_SECRET}
   authorization:
     local-policy:
       enabled: true
-      init-repository: true
+      locations:
+        - classpath:cosec-policy/*-policy.json
 ```
 
-Gateway-specific dependencies:
-```kotlin
-implementation(libs.cosec.cocache)        // Redis caching
-implementation(libs.cosec.gateway)         // Gateway filter
-implementation(libs.cosec.opentelemetry)   // Tracing
-implementation(libs.cosec.ip2region)       // IP geolocation
-implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webflux")
+Keep the JWT secret outside source control. A blank secret fails startup while JWT is enabled. Supported algorithms are `hmac256`, `hmac384`, and `hmac512`; issuer and verifier must agree.
+
+Create policies under `src/main/resources/cosec-policy/` using the configured pattern. A safe complete skeleton is:
+
+```json
+{
+  "id": "service-access",
+  "name": "Service Access",
+  "category": "access",
+  "description": "Service endpoint access",
+  "type": "global",
+  "tenantId": "(platform)",
+  "statements": [
+    {
+      "name": "Health",
+      "action": "/actuator/health"
+    }
+  ]
+}
 ```
 
-## Disabling Features
+Use `$cosec-policy-author` when the requested policy is more than this bootstrap rule.
 
-Use conditional properties to disable specific features:
+## Optional behavior
 
-```yaml
-cosec:
-  enabled: false              # disable everything
-  authorization:
-    enabled: false            # disable only authorization
-  jwt:
-    enabled: false            # disable JWT auto-config
-  ip2region:
-    enabled: false
-```
+- `local-policy.init-repository` is `false` by default. Enable it only when startup should write local policies to the configured repository; use `force-refresh` only when overwriting repository state is intended.
+- `cosec.jwt.token-revocation.enabled=true` needs a real `TokenStore`; the cache capability supplies the Redis-backed implementation. Without it, logout does not revoke tokens and the starter logs a warning.
+- The cache capability and a `StringRedisTemplate` enable `redisRateLimiter` and `redisGroupedRateLimiter`. Configure their shared prefix with `cosec.limiter.key-prefix`; use per-policy `strictFailure` when Redis outage behavior must fail closed.
+- Authorization audit logging is enabled by default. The logging sink records denies at WARN and allows at DEBUG under `me.ahoo.cosec.audit`. The Kafka capability replaces it when a unique Kafka template is available; configure `cosec.audit.kafka.topic` as needed.
+- Set `cosec.authorization.remote-ip.max-trusted-index` to the real trusted-proxy depth. `0` ignores `X-Forwarded-For`.
 
-Each auto-configuration class has a corresponding `@ConditionalOn*Enabled` annotation that checks these properties.
+## Verification
 
-## Troubleshooting
+Start the application or run its context test, then verify:
 
-- **403 on all requests**: Check that policy files exist and match the `locations` pattern. Enable debug logging: `logging.level.me.ahoo.cosec.authorization.SimpleAuthorization=debug`
-- **JWT token not recognized**: Verify `cosec.jwt.secret` and `cosec.jwt.algorithm` match what the token issuer uses
-- **Policies not loading**: Ensure `cosec.authorization.local-policy.enabled=true` and files are in the correct classpath location
-- **Root user bypasses everything**: This is by design. Root user ID defaults to `"cosec"` (override with the `cosec.root` system property)
+- policy resources are loaded with no skipped-file errors;
+- an allowed anonymous request succeeds;
+- an unmatched anonymous request returns 401;
+- an authenticated but denied request returns 403;
+- a tripped limiter returns 429;
+- Redis-backed features work from more than one instance when cluster-wide behavior is required.
 
-For deeper debugging workflows, see the `cosec-troubleshoot` skill.
+In a CoSec checkout, treat `cosec-spring-boot-starter/build.gradle.kts` and the `*Properties.kt` / auto-configuration classes under `cosec-spring-boot-starter/src/main/kotlin` as the source of truth for capabilities, defaults, and activation conditions.

--- a/skills/cosec-integration/SKILL.md
+++ b/skills/cosec-integration/SKILL.md
@@ -53,11 +53,14 @@ cosec:
   authorization:
     local-policy:
       enabled: true
+      init-repository: true
       locations:
         - classpath:cosec-policy/*-policy.json
 ```
 
 Keep the JWT secret outside source control. A blank secret fails startup while JWT is enabled. Supported algorithms are `hmac256`, `hmac384`, and `hmac512`; issuer and verifier must agree.
+
+`LocalPolicyLoader` only parses files; authorization reads `PolicyRepository`. This bootstrap configuration therefore initializes the repository at startup and requires `PolicyRepository` and `AppRolePermissionRepository` beans. The cache capability supplies Redis-backed implementations; otherwise provide them explicitly.
 
 Create policies under `src/main/resources/cosec-policy/` using the configured pattern. A safe complete skeleton is:
 
@@ -82,10 +85,10 @@ Use `$cosec-policy-author` when the requested policy is more than this bootstrap
 
 ## Optional behavior
 
-- `local-policy.init-repository` is `false` by default. Enable it only when startup should write local policies to the configured repository; use `force-refresh` only when overwriting repository state is intended.
+- `local-policy.init-repository` is `false` by default. The bootstrap above enables it because the repository is not otherwise populated from local files. Disable it only when policies are already stored elsewhere; use `force-refresh` only when overwriting repository state is intended.
 - `cosec.jwt.token-revocation.enabled=true` needs a real `TokenStore`; the cache capability supplies the Redis-backed implementation. Without it, logout does not revoke tokens and the starter logs a warning.
-- The cache capability and a `StringRedisTemplate` enable `redisRateLimiter` and `redisGroupedRateLimiter`. Configure their shared prefix with `cosec.limiter.key-prefix`; use per-policy `strictFailure` when Redis outage behavior must fail closed.
-- Authorization audit logging is enabled by default. The logging sink records denies at WARN and allows at DEBUG under `me.ahoo.cosec.audit`. The Kafka capability replaces it when a unique Kafka template is available; configure `cosec.audit.kafka.topic` as needed.
+- The cache capability and a `StringRedisTemplate` enable `redisRateLimiter` and `redisGroupedRateLimiter`. Spring registers these factories after `LocalPolicyInitializer` runs, so bootstrapped local files cannot use them; prepopulate those policies in the repository or register the factories before local initialization. Configure their shared prefix with `cosec.limiter.key-prefix`; use per-policy `strictFailure` when Redis outage behavior must fail closed.
+- With the starter's auto-configured `Authorization`, audit logging is enabled by default. The logging sink records denies at WARN and allows at DEBUG under `me.ahoo.cosec.audit`; the Kafka capability replaces it when a unique Kafka template is available. A custom `Authorization` bean is not wrapped automatically, so compose it with `AuditingAuthorization` explicitly.
 - Set `cosec.authorization.remote-ip.max-trusted-index` to the real trusted-proxy depth. `0` ignores `X-Forwarded-For`.
 
 ## Verification

--- a/skills/cosec-policy-author/SKILL.md
+++ b/skills/cosec-policy-author/SKILL.md
@@ -93,7 +93,7 @@ Order deny statements before allow statements for readability, not behavior.
 | `redisRateLimiter` | `permitsPerSecond`; optional `windowSeconds`, `strictFailure` | Cluster-wide Redis limit |
 | `redisGroupedRateLimiter` | `part`, `permitsPerSecond`; optional `windowSeconds`, `strictFailure` | Cluster-wide Redis per-part limit |
 
-The Redis types exist only when cache support and `StringRedisTemplate` activate their Spring factories. They use an atomic sliding window, return 429 when exceeded, fail open on Redis errors by default, and fail closed when `strictFailure` is `true`. The in-memory limiters also return 429 when exceeded.
+The Redis types exist only when cache support and `StringRedisTemplate` activate their Spring factories. They use an atomic sliding window, return 429 when exceeded, fail open on Redis errors by default, and fail closed when `strictFailure` is `true`. Because the starter registers these factories after local repository initialization, bootstrap local policy files cannot use them; store those policies in the repository or register the factories earlier. The in-memory limiters also return 429 when exceeded.
 
 `negate` is handled only by matchers based on `AbstractConditionMatcher`; the ungrouped `rateLimiter` and `redisRateLimiter` do not support it. Avoid negating any limiter because an exceeded quota throws before boolean negation.
 

--- a/skills/cosec-policy-author/SKILL.md
+++ b/skills/cosec-policy-author/SKILL.md
@@ -1,428 +1,150 @@
 ---
 name: cosec-policy-author
-description: "Use when writing, validating, explaining, or debugging CoSec policy JSON, policy statements, ALLOW/DENY rules, action matchers, condition matchers, role-based authorization, tenant scoping, or rate limiting policies."
+description: Write, review, validate, or explain CoSec policy JSON, including allow/deny precedence, action and condition matchers, tenant and role rules, and local or Redis rate limits. Do not use for Spring Boot setup.
 ---
 
 # CoSec Policy Authoring
 
-This skill helps you write, validate, and explain CoSec security policy JSON files. CoSec uses an AWS IAM-like policy model where policies contain statements that define ALLOW or DENY rules matched against requests.
+Produce the smallest policy that expresses the requested access rule. Establish the endpoint paths and methods, anonymous/authenticated behavior, roles or principal attributes, tenant scope, and explicit deny cases before writing JSON.
 
-## Policy JSON Structure
-
-A policy file is a single JSON object placed in `src/main/resources/cosec-policy/`. The file naming convention is `*-policy.json`.
+## Minimal complete policy
 
 ```json
 {
-  "id": "unique-policy-id",
-  "name": "Human-readable name",
-  "category": "optional-category",
-  "description": "What this policy does",
+  "id": "orders-api",
+  "name": "Orders API",
+  "category": "orders",
+  "description": "Order endpoint access",
   "type": "global",
   "tenantId": "(platform)",
-  "condition": { ... },
-  "statements": [ ... ]
-}
-```
-
-### Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `id` | Yes | Unique identifier for the policy |
-| `name` | Yes | Human-readable display name |
-| `category` | No | Logical grouping label |
-| `description` | No | Detailed description |
-| `type` | Yes | `global` (applies to all requests), `system` (system-level), or `custom` (user/role-specific) |
-| `tenantId` | Yes | Tenant scope. Use `(platform)` for global/system policies |
-| `condition` | No | Policy-level ConditionMatcher — if present and doesn't match, this policy is **skipped** (other policies still evaluate) |
-| `statements` | Yes | Array of Statement objects |
-
-## Statement Structure
-
-Each statement defines a single permission rule:
-
-```json
-{
-  "name": "StatementName",
-  "effect": "allow",
-  "action": "...",
-  "condition": { ... }
-}
-```
-
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `name` | No | `""` | Descriptive name for the statement |
-| `effect` | No | `"allow"` | `"allow"` or `"deny"`. DENY takes precedence over ALLOW |
-| `action` | Yes | — | ActionMatcher definition (see below) |
-| `condition` | No | match-all | ConditionMatcher definition (see below) |
-
-## Evaluation Order
-
-Within one evaluation tier (global policies, or principal-attached policies), CoSec pools **all statements from all policies whose policy-level condition matched**, then evaluates them deny-first:
-
-1. Policies whose policy-level `condition` doesn't match are skipped entirely — this does NOT deny the request
-2. **All DENY statements are checked first** — any match returns EXPLICIT_DENY immediately, even if an ALLOW statement in another policy would also match
-3. **ALLOW statements are checked next** — any match returns ALLOW
-4. If nothing matched in this tier, the next tier is tried; if no tier matches, the default is IMPLICIT_DENY
-
-A practical consequence: a DENY statement in ANY policy of the same tier overrides an ALLOW in ANY other policy. Write DENY statements before ALLOW rules in the statements array for readability, though the framework pools statements before evaluating.
-
-## Action Matchers
-
-The `action` field defines which requests a statement applies to. There are several formats:
-
-### Simple string — path pattern
-```json
-"action": "/api/users"
-```
-Matches the exact path. Supports Spring path patterns with wildcards and variables.
-
-### String with SpEL template
-```json
-"action": "/user/#{principal.id}/*"
-```
-`#{principal.id}` is evaluated at match time against the current security context principal.
-
-### String with path variables
-```json
-"action": "/user/{id}"
-```
-Matches path segments. Access the variable in conditions via `request.path.var.id`.
-
-### Array — multiple paths (OR logic)
-```json
-"action": ["/auth/register", "/auth/login", "/auth/logout"]
-```
-Matches if ANY path in the array matches. An array containing `"*"` matches all requests.
-
-### Wildcard
-```json
-"action": "*"
-```
-Matches all requests. Use with conditions to restrict scope.
-
-### Object — path matcher with options
-```json
-"action": {
-  "path": {
-    "method": "GET",
-    "pattern": "/api/users/*",
-    "options": {
-      "caseSensitive": false,
-      "separator": "/",
-      "decodeAndParseSegments": false
-    }
-  }
-}
-```
-
-The `method` field can be a single string or array: `"method": ["GET", "POST"]`.
-
-The `pattern` field can be a single string or array of patterns.
-
-### Object — all matcher with method filter
-```json
-"action": {
-  "all": {
-    "method": "GET"
-  }
-}
-```
-Matches all GET requests regardless of path.
-
-### Object — composite matcher (OR logic across different matcher types)
-```json
-"action": {
-  "composite": [
-    "/api/public/*",
+  "statements": [
     {
-      "path": {
-        "method": "POST",
-        "pattern": "/api/webhook/*"
+      "name": "ReadOwnOrder",
+      "action": {
+        "path": {
+          "method": "GET",
+          "pattern": "/users/{userId}/orders/*"
+        }
+      },
+      "condition": {
+        "eq": {
+          "part": "request.path.var.userId",
+          "value": "#{principal.id}"
+        }
       }
     }
   ]
 }
 ```
 
-## Condition Matchers
+Use the full field set above so both runtime deserialization and the bundled JSON Schema accept the policy. Runtime requires `id`, `name`, `type`, and `tenantId`, while the current schema requires `category`, `name`, `description`, `tenantId`, `type`, and `statements` but omits `id`. A statement requires `action`; `effect` defaults to `allow` and `condition` defaults to match-all. Local files normally live under `src/main/resources/cosec-policy/` and match `*-policy.json`.
 
-The `condition` field adds additional constraints beyond path matching. An omitted condition defaults to match-all (`all`). All condition types:
+## Evaluation semantics
 
-### authenticated — user must be logged in
+Authorization evaluates in tiers: root bypass, blacklist, global policies, principal-attached policies, then role permissions. The first tier that produces a result stops evaluation.
+
+Within a policy tier, CoSec first evaluates every matched policy-level condition, pools their statements, checks all `deny` statements, then all `allow` statements. Therefore:
+
+- a matching deny overrides every allow in the same tier, regardless of file or array order;
+- a false policy-level condition skips that policy; it does not deny the request;
+- an allow in an earlier tier prevents later tiers from running, so a principal or role deny cannot override a global allow;
+- if no statement in any tier matches, the result is implicit deny.
+
+Order deny statements before allow statements for readability, not behavior.
+
+## Action forms
+
 ```json
-"condition": { "authenticated": {} }
+"action": "/api/users/{id}"
 ```
 
-### inRole — user must have the specified role
 ```json
-"condition": { "inRole": { "value": "admin" } }
+"action": ["/auth/login", "/auth/refresh"]
 ```
 
-### inTenant — request must be from the specified tenant type
 ```json
-"condition": { "inTenant": { "value": "platform" } }
-```
-`value` is a tenant **type** — `default`, `user`, or `platform` — not a tenant ID. Any other string makes the policy fail to load: the error is logged and the policy is **silently skipped** at startup, so its rules stop applying (watch for 403s).
-
-### eq — exact value match
-```json
-"condition": {
-  "eq": {
-    "part": "request.path.var.id",
-    "value": "#{principal.id}"
-  }
-}
-```
-
-The `part` field is a path expression that extracts a value from the request or security context:
-- `request.path` — full request path
-- `request.path.var.{name}` — path variable
-- `request.method` — HTTP method
-- `request.remoteIp` — client IP
-- `request.origin` — request origin; `request.origin.host` — origin host
-- `request.referer` — referer; `request.referer.host` — referer host
-- `request.appId` / `request.spaceId` / `request.deviceId` — request identifiers
-- `request.header.{name}` — request header (singular `header`)
-- `request.attributes.{key}` — request attributes (e.g., `request.attributes.ipRegion`)
-- `context.tenantId` — current tenant ID
-- `context.principal.id` — current user ID
-- `context.principal.attributes.{key}` — principal attributes
-
-The `value` field supports SpEL templates like `#{principal.id}`.
-
-### contains — substring match
-```json
-"condition": {
-  "contains": {
-    "part": "request.attributes.ipRegion",
-    "value": "上海"
-  }
-}
-```
-
-### startsWith / endsWith — prefix/suffix match
-```json
-"condition": {
-  "startsWith": {
-    "part": "request.attributes.ipRegion",
-    "value": "中国"
-  }
-}
-```
-
-### in — value must be in a list
-```json
-"condition": {
-  "in": {
-    "part": "context.principal.id",
-    "value": ["adminId", "developerId"]
-  }
-}
-```
-
-### regular — regex match
-```json
-"condition": {
-  "regular": {
-    "negate": true,
-    "part": "request.origin",
-    "pattern": "^(http|https)://github.com"
-  }
-}
-```
-Set `negate: true` to invert the match (matches when regex does NOT match).
-
-### path — path pattern match on arbitrary values
-```json
-"condition": {
+"action": {
   "path": {
-    "part": "request.remoteIp",
-    "pattern": "192.168.0.*",
-    "options": {
-      "caseSensitive": false,
-      "separator": ".",
-      "decodeAndParseSegments": false
-    }
+    "method": ["GET", "HEAD"],
+    "pattern": ["/api/users/*", "/api/teams/*"]
   }
 }
 ```
 
-### bool — boolean logic (AND/OR)
+`"*"` or `{ "all": { "method": "GET" } }` matches all paths. `{ "composite": [...] }` ORs heterogeneous action matchers. Path patterns support variables such as `{id}` and SpEL templates such as `#{principal.id}`.
+
+## Condition reference
+
+| Type | Required configuration | Purpose |
+|---|---|---|
+| `all` | none | Always match |
+| `authenticated` | none | Require a non-anonymous principal |
+| `inRole` | `value` | Match a principal role |
+| `inTenant` | `value`: `default`, `user`, or `platform` | Match tenant type, not tenant ID |
+| `eq`, `contains`, `startsWith`, `endsWith` | `part`, `value` | Compare an extracted string |
+| `in` | `part`, array `value` | Match one of several values |
+| `regular` | `part`, `pattern` | Regex match with a time budget |
+| `path` | `part`, `pattern`, optional `options` | Spring path-pattern match on an extracted value |
+| `bool` | optional sibling arrays `and`, `or` | Combine conditions |
+| `spel` | `expression` | Evaluate against root properties `request` and `context` |
+| `ognl` | `expression` | Sandboxed expression using `#request` and `#context` |
+| `rateLimiter` | `permitsPerSecond` | One in-memory limit per matcher/JVM |
+| `groupedRateLimiter` | `part`, `permitsPerSecond`, `expireAfterAccessSecond` | In-memory per-part limit |
+| `redisRateLimiter` | `permitsPerSecond`; optional `windowSeconds`, `strictFailure` | Cluster-wide Redis limit |
+| `redisGroupedRateLimiter` | `part`, `permitsPerSecond`; optional `windowSeconds`, `strictFailure` | Cluster-wide Redis per-part limit |
+
+The Redis types exist only when cache support and `StringRedisTemplate` activate their Spring factories. They use an atomic sliding window, return 429 when exceeded, fail open on Redis errors by default, and fail closed when `strictFailure` is `true`. The in-memory limiters also return 429 when exceeded.
+
+`negate` is handled only by matchers based on `AbstractConditionMatcher`; the ungrouped `rateLimiter` and `redisRateLimiter` do not support it. Avoid negating any limiter because an exceeded quota throws before boolean negation.
+
+### Boolean example
+
 ```json
-"condition": {
+{
   "bool": {
     "and": [
       { "authenticated": {} }
     ],
     "or": [
-      { "in": { "part": "context.principal.id", "value": ["dev1"] } },
-      { "path": { "part": "request.remoteIp", "pattern": "10.0.0.*" } }
+      { "inRole": { "value": "admin" } },
+      { "in": { "part": "context.principal.id", "value": ["support-1", "support-2"] } }
     ]
   }
 }
 ```
-All items in `and` must match. At least one item in `or` must match. Both are optional — you can use just `and`, just `or`, or both.
 
-### spel / ognl — expression-based
-```json
-"condition": {
-  "spel": {
-    "expression": "#principal.attributes['vip'] == 'true'"
-  }
-}
+All `and` entries must match. If `or` is present, at least one entry must match. `and` and `or` are sibling fields.
+
+## Valid part paths
+
+- `request.path`, `request.method`, `request.remoteIp`
+- `request.origin`, `request.origin.host`, `request.referer`, `request.referer.host`
+- `request.appId`, `request.spaceId`, `request.deviceId`
+- `request.header.{name}`, `request.attributes.{key}`, `request.path.var.{name}`
+- `context.tenantId`, `context.principal.id`, `context.principal.attributes.{key}`
+
+Use singular `request.header`, and use `request.path.var.id` only after the action matcher captures `{id}`. An unsupported part throws during evaluation.
+
+## Security review
+
+Check the final policy for:
+
+- accidental broad global allows that short-circuit stricter principal or role tiers;
+- deny conditions whose negation is reversed;
+- missing HTTP method constraints on state-changing endpoints;
+- trusted-proxy assumptions behind `request.remoteIp`;
+- tenant type (`inTenant`) being confused with tenant ID (`context.tenantId`);
+- unsafe or needlessly complex expressions when a built-in matcher suffices;
+- local limiters used where a cluster-wide quota is required.
+
+## Validation
+
+Validate with CoSec's runtime parser, not JSON syntax alone. In a CoSec-based test:
+
+```kotlin
+val policies = LocalPolicyLoader(setOf("classpath:cosec-policy/orders-policy.json")).policies
+require(policies.isNotEmpty())
+policies.forEach(DefaultPolicyEvaluator::evaluate)
 ```
 
-### rateLimiter — rate limiting
-```json
-"condition": {
-  "rateLimiter": {
-    "permitsPerSecond": 10
-  }
-}
-```
-When the limit is exceeded the request fails with TOO_MANY_REQUESTS (HTTP 429) rather than a normal deny. `rateLimiter` creates a single limiter shared by all matching requests; `groupedRateLimiter` creates one per group value. Both are in-memory and per-JVM-instance — `cosec-cocache` provides **no** rate limiting (it only caches policies/permissions/tokens), so a limit shared across instances requires a custom ConditionMatcher backed by Redis or another shared store.
-
-### groupedRateLimiter — per-group rate limiting
-```json
-"condition": {
-  "groupedRateLimiter": {
-    "part": "context.principal.id",
-    "permitsPerSecond": 100,
-    "expireAfterAccessSecond": 60
-  }
-}
-```
-The group is selected by `part` (any valid part path, e.g. `context.principal.id` for per-user limits). Both `permitsPerSecond` and `expireAfterAccessSecond` (idle expiry of each group's limiter) are required. Exceeding the limit yields TOO_MANY_REQUESTS.
-
-## Common Patterns
-
-### Public endpoints (no auth required)
-```json
-{
-  "id": "public-api",
-  "name": "Public API",
-  "type": "global",
-  "tenantId": "(platform)",
-  "statements": [
-    {
-      "name": "PublicEndpoints",
-      "action": ["/auth/login", "/auth/register", "/health"]
-    }
-  ]
-}
-```
-
-### Admin-only endpoints
-```json
-{
-  "id": "admin-api",
-  "name": "Admin API",
-  "type": "global",
-  "tenantId": "(platform)",
-  "statements": [
-    {
-      "name": "AdminOnly",
-      "action": "/admin/**",
-      "condition": { "inRole": { "value": "admin" } }
-    }
-  ]
-}
-```
-
-### User can only access their own resources
-```json
-{
-  "name": "OwnResourcesOnly",
-  "action": "/api/users/{id}/**",
-  "condition": {
-    "eq": {
-      "part": "request.path.var.id",
-      "value": "#{principal.id}"
-    }
-  }
-}
-```
-
-### IP whitelist with deny
-```json
-{
-  "name": "BlockExternalIp",
-  "effect": "deny",
-  "action": "*",
-  "condition": {
-    "regular": {
-      "negate": true,
-      "part": "request.remoteIp",
-      "pattern": "^(10\\.0\\.0\\.|192\\.168\\.)"
-    }
-  }
-}
-```
-
-### CORS origin restriction
-```json
-{
-  "name": "RestrictOrigin",
-  "effect": "deny",
-  "action": "*",
-  "condition": {
-    "regular": {
-      "negate": true,
-      "part": "request.origin",
-      "pattern": "^https://(app\\.example\\.com|admin\\.example\\.com)"
-    }
-  }
-}
-```
-
-### Rate-limited authenticated API
-```json
-{
-  "name": "RateLimitedApi",
-  "action": "/api/**",
-  "condition": {
-    "bool": {
-      "and": [
-        { "authenticated": {} },
-        { "rateLimiter": { "permitsPerSecond": 10 } }
-      ]
-    }
-  }
-}
-```
-
-### Health probe (for Kubernetes)
-```json
-{
-  "id": "(health-probe)",
-  "name": "Health Probe",
-  "type": "global",
-  "tenantId": "(platform)",
-  "statements": [
-    {
-      "name": "actuator",
-      "action": [
-        "/actuator/health",
-        "/actuator/health/readiness",
-        "/actuator/health/liveness"
-      ]
-    }
-  ]
-}
-```
-
-## Validation Checklist
-
-When reviewing a policy, check:
-
-1. **DENY before ALLOW** — DENY in any same-tier policy overrides ALLOW elsewhere; writing DENY statements first improves readability
-2. **SpEL templates** — `#{principal.id}` is valid; `{principal.id}` is NOT (it is parsed as a path variable or literal)
-3. **Path variables** — use `{varName}` syntax, access via `request.path.var.varName` in conditions
-4. **Wildcard with conditions** — `"action": "*"` alone allows everything; always pair with a condition
-5. **Negate logic** — every condition matcher accepts `negate: true` (handled centrally in `AbstractConditionMatcher`); `rateLimiter` is the only exception
-6. **Bool structure** — `and` and `or` are sibling fields, not nested
-7. **Part paths** — must be valid (singular `request.header.{name}`, not `request.headers.{name}`); invalid parts throw `IllegalArgumentException` at evaluation time
-8. **Policy type** — `global` policies apply to all requests; `custom` policies are attached to specific users/roles
-9. **groupedRateLimiter** — requires `part`, `permitsPerSecond`, and `expireAfterAccessSecond`; there is no `groupKey` field
+`LocalPolicyLoader` logs and skips malformed policies, so assert that the expected policy ID loaded. `DefaultPolicyEvaluator` catches expected rate-limit and regex-timeout signals but surfaces other matcher configuration errors. Add one authorization test for each meaningful allow/deny boundary.

--- a/skills/cosec-troubleshoot/SKILL.md
+++ b/skills/cosec-troubleshoot/SKILL.md
@@ -20,7 +20,7 @@ logging:
     me.ahoo.cosec.audit: DEBUG
 ```
 
-`SimpleAuthorization` identifies the matched policy/statement or role/permission. The default audit sink emits structured deny events at WARN and allow events at DEBUG, including principal, request, decision, and matched rule when available.
+`SimpleAuthorization` identifies the matched policy/statement or role/permission. When `AuditingAuthorization` is active, the default sink emits structured deny events at WARN and allow events at DEBUG, including principal, request, decision, and matched rule when available. A custom `Authorization` bean is not wrapped automatically.
 
 ## Interpret the status first
 
@@ -75,9 +75,10 @@ Each policy tier evaluates matched policy-level conditions once, pools all state
 ### Policy file has no effect
 
 - Confirm `cosec.authorization.local-policy.enabled=true` and the file matches `local-policy.locations`.
-- Inspect startup errors: `LocalPolicyLoader` logs and skips malformed JSON, missing required fields, unknown matcher types, and invalid matcher configuration rather than failing the application.
+- Inspect startup errors: `LocalPolicyLoader` logs and skips malformed JSON, missing required fields, unknown matcher types, and constructor-time configuration errors rather than failing the application.
+- Deferred matcher errors still load. For example, an unsupported `part` throws during authorization and the transport returns 500; reproduce it with `DefaultPolicyEvaluator` or the failing request.
 - Local policies are deduplicated by ID after location expansion; assert that the expected ID and content loaded.
-- `init-repository` controls repository writes, not local parsing. Use `force-refresh` only when overwriting repository state is intended.
+- `LocalPolicyLoader` does not serve authorization decisions directly. Enable `init-repository` or prepopulate `PolicyRepository`; use `force-refresh` only when overwriting repository state is intended.
 
 ### Matcher mismatch
 

--- a/skills/cosec-troubleshoot/SKILL.md
+++ b/skills/cosec-troubleshoot/SKILL.md
@@ -1,292 +1,112 @@
 ---
 name: cosec-troubleshoot
-description: "Use when diagnosing CoSec authentication or authorization failures such as unexpected 401/403 responses, denied requests that should be allowed, policies not loading, JWT token rejection, matcher mismatches, or unclear access decisions."
+description: Diagnose CoSec authentication and authorization failures, including unexpected 401/403/429 responses, policy loading, JWT rejection, matcher mismatches, Redis limiters, and unexplained access decisions. Do not change behavior unless the user asks for a fix.
 ---
 
-# CoSec Troubleshooting Guide
+# CoSec Troubleshooting
 
-This skill helps you debug authorization issues in CoSec. When a request gets an unexpected result (403, 401, 429, or is allowed when it shouldn't be), follow this systematic approach.
+Find the first incorrect transition from request parsing to authentication, policy loading, matching, and response mapping. Gather evidence before proposing a policy or code change.
 
-## Step 1: Enable Debug Logging
+## Start with observable facts
 
-The fastest way to understand authorization decisions is debug logging on `SimpleAuthorization`:
+Capture the request method/path, response status and CoSec JSON reason, principal ID/authenticated state, app/space/tenant IDs, effective configuration, loaded policy IDs, and relevant startup/request logs. Redact tokens and secrets.
+
+Enable focused logging:
 
 ```yaml
 logging:
   level:
-    me.ahoo.cosec.authorization.SimpleAuthorization: debug
+    me.ahoo.cosec.authorization.SimpleAuthorization: DEBUG
+    me.ahoo.cosec.audit: DEBUG
 ```
 
-This logs every matched statement, the policy/statement it came from, and the final result, e.g. `Verify [request] [context] matched Policy[globalPolicy] Statement[2][RequestOriginDeny] - [EXPLICIT_DENY].` (statement index is 0-based)
+`SimpleAuthorization` identifies the matched policy/statement or role/permission. The default audit sink emits structured deny events at WARN and allow events at DEBUG, including principal, request, decision, and matched rule when available.
 
-For more granular tracing:
-```yaml
-logging:
-  level:
-    me.ahoo.cosec.policy: debug
-    me.ahoo.cosec.authentication: debug
-    me.ahoo.cosec.jwt: debug
+## Interpret the status first
+
+| HTTP status | CoSec meaning |
+|---|---|
+| 400 | Invalid normalized request path |
+| 401 | Authorization denied while the parsed principal is anonymous; invalid/expired tokens also fall back to anonymous and preserve the token reason |
+| 403 | An authenticated principal was denied, or a regex matcher timed out and failed closed |
+| 429 | A local or Redis rate limiter threw `TooManyRequestsException` |
+| 500 | Unexpected authorization error; inspect the server exception |
+
+The authorization result alone does not choose 401 versus 403; the filter maps a denied anonymous principal to 401 and a denied authenticated principal to 403.
+
+## Decision order
+
+`SimpleAuthorization` evaluates:
+
+1. Root principal ID (`cosec` by default, overridden by JVM system property `cosec.root`) → allow.
+2. Blacklist → explicit deny.
+3. Global policies.
+4. Principal-attached policies.
+5. Role permissions for `request.appId` + `request.spaceId`.
+6. No match → implicit deny.
+
+Each policy tier evaluates matched policy-level conditions once, pools all statements, checks every deny before any allow, and stops at the first tier with a result. A deny only overrides allows in the same tier; a global allow prevents later principal or role denies from running.
+
+## Symptom guide
+
+### Unexpected 401
+
+- Check whether the request actually carried a bearer token and whether parsing produced an authenticated principal.
+- Match `cosec.jwt.algorithm` and secret to the issuer; only HMAC256/384/512 are supported.
+- Check expiration and the response reason (`Token Expired` versus `Token Invalid`).
+- If revocation is enabled, verify the cache capability supplied a real Redis-backed `TokenStore`; otherwise the starter warns that logout is ineffective.
+- If the token is valid but the request remains anonymous, inspect the active `SecurityContextParser` and transport filter.
+
+### Unexpected 403 or missing allow
+
+- Read the debug/audit match. An explicit deny is a matched deny; an implicit deny means no rule in any tier matched.
+- Confirm a global policy loaded and its policy-level condition matched.
+- Check the action's HTTP method, path, trailing slash, and captured variables.
+- Check condition parts and the actual principal roles/attributes/tenant.
+- Remember that `inTenant.value` is `default`, `user`, or `platform`, not a tenant ID.
+
+### Request allowed unexpectedly
+
+- Check root bypass first.
+- Find the first matched tier. A broad global allow short-circuits stricter principal and role rules.
+- Verify the deny action and condition both match; array order cannot make an allow beat a same-tier deny.
+- Confirm the intended policy was loaded rather than skipped or shadowed by a duplicate ID.
+
+### Policy file has no effect
+
+- Confirm `cosec.authorization.local-policy.enabled=true` and the file matches `local-policy.locations`.
+- Inspect startup errors: `LocalPolicyLoader` logs and skips malformed JSON, missing required fields, unknown matcher types, and invalid matcher configuration rather than failing the application.
+- Local policies are deduplicated by ID after location expansion; assert that the expected ID and content loaded.
+- `init-repository` controls repository writes, not local parsing. Use `force-refresh` only when overwriting repository state is intended.
+
+### Matcher mismatch
+
+- Path variables use `{id}` and conditions read `request.path.var.id`; `:id` and `request.pathVariable.id` are invalid.
+- Path SpEL templates use `#{principal.id}`. SpEL condition expressions use root properties such as `context.principal.id`; they are different evaluation roots.
+- Valid part prefixes are singular `request.header.`, `request.attributes.`, `request.path.var.`, and `context.principal.attributes.`. Unsupported parts throw `IllegalArgumentException`.
+- Regex timeouts fail closed as 403. Simplify or bound the pattern instead of increasing exposure to ReDoS.
+
+### Rate limiting differs across instances
+
+- `rateLimiter` and `groupedRateLimiter` are in-memory and per JVM.
+- `redisRateLimiter` and `redisGroupedRateLimiter` are cluster-wide and require cache support plus `StringRedisTemplate`.
+- Redis limiter outages fail open by default. Set the matcher's `strictFailure: true` only when availability loss should return 429.
+- Check `cosec.limiter.key-prefix`, `windowSeconds`, grouping `part`, and whether multiple policies intentionally share an identical quota configuration.
+
+## Reproduce narrowly
+
+Prefer the smallest existing test layer that crosses the failing boundary:
+
+- matcher behavior: create the real factory with `mapOf(...).asConfiguration()` and test `match`;
+- policy parsing: load the exact resource with `LocalPolicyLoader`, assert its ID, then run `DefaultPolicyEvaluator.evaluate`;
+- decision order: test `SimpleAuthorization` with the smallest repositories needed;
+- transport mapping: use the WebFlux, WebMVC, or Gateway filter tests for 401/403/429 behavior;
+- Redis behavior: run the cache integration test with Redis.
+
+In this repository, run a focused class first, for example:
+
+```bash
+./gradlew :cosec-core:test --tests "me.ahoo.cosec.policy.DefaultPolicyEvaluatorTest"
 ```
 
-## Step 2: Understand the Evaluation Order
-
-`SimpleAuthorization.authorize` evaluates in this order, falling through with `switchIfEmpty` when a step produces no match:
-
-```
-1. Root user check
-   └─ If principal.id == root ID (default "cosec") → ALLOW (bypass everything)
-
-2. Blacklist check
-   └─ If principal is blacklisted → EXPLICIT_DENY
-
-3. Global policies (type: "global")
-   └─ Skip policies whose policy-level condition doesn't match
-   └─ Pool ALL statements from ALL matched policies, then deny-first:
-      a. Check every DENY statement → EXPLICIT_DENY if any matches
-      b. Check every ALLOW statement → ALLOW if any matches
-
-4. Principal-specific policies
-   └─ Policies attached to the user (via policy IDs on the principal)
-   └─ Same pooled deny-first evaluation as global policies
-
-5. Role-based app permissions
-   └─ Only when the principal has roles; permissions are looked up
-      by request.appId + request.spaceId, then evaluated deny-first
-
-6. Default → IMPLICIT_DENY
-```
-
-Key consequence: a DENY statement in ANY policy of the same tier beats an ALLOW statement in ANY other policy of that tier — policy order within a tier does not matter.
-
-## Step 3: Common Issues and Fixes
-
-### All requests return 403
-
-**Symptoms:** Every endpoint returns 403, even public ones.
-
-**Likely causes:**
-1. No policy files loaded — check `cosec.authorization.local-policy.enabled=true`
-2. Policy files don't match the location pattern — default is `classpath:cosec-policy/*-policy.json`
-3. Policy JSON syntax error — check startup logs for deserialization errors
-
-**Fix:**
-```yaml
-cosec:
-  authorization:
-    local-policy:
-      enabled: true
-      locations: classpath:cosec-policy/*-policy.json
-```
-
-### Specific endpoint returns 403 when it should be public
-
-**Symptoms:** Most endpoints work, but a new public endpoint returns 403.
-
-**Cause:** No ALLOW statement matches the endpoint. By default, CoSec uses implicit deny — anything not explicitly allowed is denied.
-
-**Fix:** Add a statement for the endpoint:
-```json
-{
-  "name": "NewPublicEndpoint",
-  "action": "/api/new-endpoint"
-}
-```
-
-### Request allowed when it should be denied
-
-**Symptoms:** A request that should be blocked gets through.
-
-**Likely causes:**
-1. DENY statement doesn't match — check action pattern and condition
-2. An ALLOW statement in a LATER tier matches (tiers fall through: global → principal → role permissions) — a DENY only overrides ALLOW within the same tier
-3. Root user bypass — check if the user ID equals the root ID (default `"cosec"`, override with the `cosec.root` system property)
-
-**Debug:** Enable debug logging and check which statement matched.
-
-### JWT token rejected
-
-**Symptoms:** Requests with valid JWT tokens return 401.
-
-**Likely causes:**
-1. `cosec.jwt.secret` doesn't match the token issuer's secret
-2. `cosec.jwt.algorithm` doesn't match the token's algorithm (supported: `hmac256`, `hmac384`, `hmac512`)
-3. Token is expired (`token-validity.access` defaults to 10 minutes)
-4. Token was revoked (logout) while `cosec.jwt.token-revocation.enabled=true`
-
-**Check:**
-```yaml
-cosec:
-  jwt:
-    algorithm: hmac256    # must match the signing algorithm
-    secret: exact-same-secret-used-by-issuer
-    token-validity:
-      access: 10m         # access token TTL
-      refresh: 7d         # refresh token TTL
-    token-revocation:
-      enabled: false      # when true, revoked (logged-out) tokens are rejected
-```
-
-### Policies not loading from local files
-
-**Symptoms:** Startup succeeds but policies don't take effect.
-
-**Checklist:**
-1. File location: `src/main/resources/cosec-policy/` (not `resources/main/...`)
-2. File naming: must match `*-policy.json` pattern
-3. Property: `cosec.authorization.local-policy.enabled=true`
-4. JSON validity: parse errors are logged at startup
-5. Policy type: must be `"global"` for the policy to apply to all requests
-
-### Rate limiter not working
-
-**Symptoms:** Limits are per-instance instead of shared across the cluster.
-
-**Cause:** Both `rateLimiter` and `groupedRateLimiter` keep state in memory, per JVM instance — there is no built-in distributed limiter, and `cosec-cocache` does not provide one (it only caches policies/permissions/tokens).
-
-**Fix:** Implement a custom `ConditionMatcher` backed by a shared store such as Redis — see the `cosec-custom-matcher` skill. Also note: a tripped limiter produces `TOO_MANY_REQUESTS` (HTTP 429), not a plain 403.
-
-### Path variables not matching
-
-**Symptoms:** `/user/123` doesn't match `/user/{id}`.
-
-**Check:**
-1. Use `{varName}` — the `:varName` colon syntax is not supported by CoSec's path patterns
-2. Access the variable via `request.path.var.varName` in conditions
-3. Ensure the path pattern is correct (no trailing slash mismatch)
-
-### SpEL template not evaluating
-
-**Symptoms:** `#{principal.id}` is treated as a literal string.
-
-**Cause:** SpEL templates use `#{}` syntax. `{}` alone is a path variable, not SpEL.
-
-**Fix:** Use `#{principal.id}` not `{principal.id}`.
-
-### Condition part path is wrong
-
-**Symptoms:** Condition always returns false, or evaluation throws `IllegalArgumentException: Unsupported part`.
-
-**Valid part paths:**
-- `request.path` — full request path
-- `request.path.var.{name}` — path variable
-- `request.method` — HTTP method
-- `request.remoteIp` — client IP address
-- `request.origin` — Origin; `request.origin.host` — origin host
-- `request.referer` — Referer; `request.referer.host` — referer host
-- `request.appId` / `request.spaceId` / `request.deviceId` — identifiers
-- `request.header.{name}` — request header (singular `header`)
-- `request.attributes.{key}` — request attributes
-- `context.tenantId` — tenant ID
-- `context.principal.id` — user ID
-- `context.principal.attributes.{key}` — principal attribute
-
-Common mistakes:
-- `request.headers.X-Foo` (wrong) → `request.header.X-Foo` (correct)
-- `request.ip` (wrong) → `request.remoteIp` (correct)
-- `principal.id` (wrong) → `context.principal.id` (correct)
-- `request.pathVariable.id` (wrong) → `request.path.var.id` (correct)
-
-## Step 4: Testing Policies Locally
-
-These patterns mirror the real tests in `cosec-core/src/test/kotlin/me/ahoo/cosec/authorization/SimpleAuthorizationTest.kt`.
-
-### Unit test a full authorization decision
-
-```kotlin
-@Test
-fun `test policy evaluation`() {
-    val globalPolicy = mockk<Policy> {
-        every { id } returns "globalPolicy"
-        every { condition } returns AllConditionMatcher.INSTANCE
-        every { statements } returns listOf(
-            StatementData(
-                name = "PublicEndpoints",
-                effect = Effect.ALLOW,
-                action = PathActionMatcherFactory.INSTANCE
-                    .create(mapOf("pattern" to "/api/users/*").asConfiguration()),
-            ),
-        )
-    }
-    val policyRepository = mockk<PolicyRepository> {
-        every { getGlobalPolicy() } returns Mono.just(listOf(globalPolicy))
-        every { getPolicies(any()) } returns Mono.empty()
-    }
-    val permissionRepository = mockk<AppRolePermissionRepository> {
-        every { getAppRolePermission(any(), any(), any()) } returns Mono.empty()
-    }
-
-    val authorization = SimpleAuthorization(policyRepository, permissionRepository)
-    val request = mockk<Request> {
-        every { path } returns "/api/users/123"
-        every { method } returns "GET"
-    }
-    // relaxed: evaluation writes path variables and the verify context into the context
-    val securityContext = mockk<SecurityContext>(relaxed = true) {
-        every { principal.id } returns "user-123"
-    }
-
-    authorization.authorize(request, securityContext)
-        .test()
-        .expectNext(AuthorizeResult.ALLOW)
-        .verifyComplete()
-}
-```
-
-Imports worth knowing: `me.ahoo.cosec.configuration.JsonConfiguration.Companion.asConfiguration` for building matchers from maps, `me.ahoo.cosec.policy.StatementData` / `me.ahoo.cosec.policy.action.PathActionMatcherFactory` for real (non-mock) matchers, and `reactor.kotlin.test.test` for stepping through the `Mono`.
-
-### Smoke-test a local policy file
-
-`LocalPolicyLoader` takes a set of resource patterns and exposes loaded policies as a property; `DefaultPolicyEvaluator` is a stateless object that dry-runs every matcher of a policy against a mock request to surface configuration errors (it swallows rate-limit and regex-timeout errors):
-
-```kotlin
-val policies = LocalPolicyLoader(setOf("classpath:cosec-policy/test-policy.json")).policies
-policies.forEach { DefaultPolicyEvaluator.evaluate(it) }
-```
-
-### Test a specific matcher
-
-```kotlin
-@Test
-fun `test path action matcher`() {
-    val matcher = PathActionMatcherFactory.INSTANCE
-        .create(mapOf("pattern" to "/api/users/*").asConfiguration())
-
-    val request = mockk<Request> {
-        every { path } returns "/api/users/123"
-        every { method } returns "GET"
-    }
-
-    matcher.match(request, SimpleSecurityContext.anonymous()).assert().isTrue()
-}
-```
-
-## Step 5: Request Attributes for Debugging
-
-When debugging, inspect the request attributes that CoSec sets:
-
-- `COSEC_SECURITY_CONTEXT` — the parsed security context
-- `request.attributes.ipRegion` — IP geolocation (if `cosec-ip2region` is enabled)
-
-In a WebFlux handler:
-```kotlin
-@GetMapping("/debug/whoami")
-fun whoami(exchange: ServerWebExchange): Mono<Map<String, Any?>> {
-    val context = exchange.getAttribute<SecurityContext>(COSEC_SECURITY_CONTEXT)
-    return Mono.just(mapOf(
-        "principal" to context?.principal?.id,
-        "authenticated" to context?.principal?.authenticated,
-        "roles" to context?.principal?.roles,
-        "tenant" to context?.tenant?.tenantId
-    ))
-}
-```
-
-## Quick Reference: Authorization Results
-
-| Result | `authorized` | Meaning |
-|--------|-------------|---------|
-| `ALLOW` | `true` | Explicitly allowed by a policy statement |
-| `EXPLICIT_DENY` | `false` | Explicitly denied by a DENY statement or blacklist |
-| `IMPLICIT_DENY` | `false` | No statement matched (default deny) |
-| `TOKEN_EXPIRED` | `false` | JWT token has expired |
-| `TOO_MANY_REQUESTS` | `false` | Rate limiter exceeded |
+Use `$cosec-policy-author` to rewrite a confirmed-bad policy and `$cosec-integration` to change confirmed-bad Spring configuration. For diagnosis-only requests, report the root cause and evidence without modifying files.

--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -25,7 +25,9 @@
         "multi-tenant",
         "spring-boot",
         "reactive",
-        "jwt"
+        "jwt",
+        "rate-limiting",
+        "audit"
       ],
       "category": "development",
       "interface": {


### PR DESCRIPTION
## Summary

- streamline the four CoSec skill entrypoints from 1,275 to 466 lines
- tighten skill routing and remove duplicated tutorials and pinned version examples
- align guidance with current Redis distributed rate limiting, authorization auditing, Gradle capabilities, and runtime behavior
- clarify non-Gradle companion dependencies and the runtime/schema policy-field mismatch
- update matcher invocation metadata and plugin discovery keywords

## Why

The skills duplicated reference material, carried a stale fixed CoSec version, and predated the Redis limiter and audit additions. Some integration guidance also made direct CoSec modules look like complete replacements for feature variants, while policy validation did not explain the checked-in schema's difference from runtime deserialization.

## Impact

Skill context is about 63% smaller while preserving the non-obvious authorization, matcher, integration, and troubleshooting constraints. Maven and other non-Gradle users now get the required companion dependency warning, and policy authors are guided to a field set accepted by both runtime and schema validation.

## Validation

- all four skills pass `quick_validate.py`
- `skills/plugins.json` passes `jq empty`
- `git diff --check`
- focused core, WebFlux, audit, and Redis auto-configuration tests
- `./gradlew detekt`
