### PR TITLE
Improve audit event identifiers and trace validation

### DIFF
--- a/cosec-core/build.gradle.kts
+++ b/cosec-core/build.gradle.kts
@@ -13,6 +13,7 @@
 
 dependencies {
     api(project(":cosec-api"))
+    api("me.ahoo.cosid:cosid-core")
     compileOnly("ognl:ognl")
     compileOnly("org.springframework:spring-web")
     compileOnly("org.springframework:spring-expression")

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditEventExtractor.kt
@@ -46,6 +46,7 @@ object AuditEventExtractor {
         result: AuthorizeResult,
         elapsedNanos: Long,
         verifyContext: VerifyContext? = context.getVerifyContext(),
+        eventId: String = UUID.randomUUID().toString(),
     ): AuditEvent {
         val decision = toDecision(result)
         return eventOf(
@@ -56,6 +57,7 @@ object AuditEventExtractor {
             reason = result.reason,
             elapsedNanos = elapsedNanos,
             verifyContext = verifyContext,
+            eventId = eventId,
         )
     }
 
@@ -65,6 +67,7 @@ object AuditEventExtractor {
         error: Throwable,
         elapsedNanos: Long,
         verifyContext: VerifyContext? = context.getVerifyContext(),
+        eventId: String = UUID.randomUUID().toString(),
     ): AuditEvent {
         val (decision, reasonCode, reason) = when (error) {
             is TooManyRequestsException -> Triple(
@@ -81,7 +84,7 @@ object AuditEventExtractor {
 
             else -> Triple(AuditDecision.ERROR, AuditReasonCode.ERROR, error.javaClass.simpleName)
         }
-        return eventOf(request, context, decision, reasonCode, reason, elapsedNanos, verifyContext)
+        return eventOf(request, context, decision, reasonCode, reason, elapsedNanos, verifyContext, eventId)
     }
 
     private fun toDecision(result: AuthorizeResult): AuditDecision {
@@ -115,9 +118,10 @@ object AuditEventExtractor {
         reason: String,
         elapsedNanos: Long,
         verifyContext: VerifyContext?,
+        eventId: String,
     ): AuditEvent {
         return AuditEventData(
-            eventId = UUID.randomUUID().toString(),
+            eventId = eventId,
             timestamp = Instant.now(),
             tenantId = context.tenant.tenantId,
             principal = AuditPrincipalData(

--- a/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
+++ b/cosec-core/src/main/kotlin/me/ahoo/cosec/audit/AuditingAuthorization.kt
@@ -23,6 +23,8 @@ import me.ahoo.cosec.api.context.request.Request
 import me.ahoo.cosec.authorization.VerifyContextScope
 import me.ahoo.cosec.token.TokenVerificationContexts.getTokenVerificationException
 import me.ahoo.cosec.token.toAuthorizeResult
+import me.ahoo.cosid.IdGenerator
+import me.ahoo.cosid.jvm.UuidGenerator
 import reactor.core.publisher.Mono
 
 /**
@@ -30,9 +32,10 @@ import reactor.core.publisher.Mono
  * Every audit step (event construction and publishing) is failure-isolated
  * and never alters the delegated result or error signals.
  */
-class AuditingAuthorization(
+class AuditingAuthorization @JvmOverloads constructor(
     override val delegate: Authorization,
     private val auditEventSink: AuditEventSink,
+    private val idGenerator: IdGenerator = UuidGenerator.INSTANCE,
 ) : Authorization,
     Delegated<Authorization> {
 
@@ -54,6 +57,7 @@ class AuditingAuthorization(
                             result = effectiveResult,
                             elapsedNanos = System.nanoTime() - startNanos,
                             verifyContext = verifyContextScope.value,
+                            eventId = idGenerator.generateAsString(),
                         )
                     }
                 }
@@ -65,6 +69,7 @@ class AuditingAuthorization(
                             error = error,
                             elapsedNanos = System.nanoTime() - startNanos,
                             verifyContext = verifyContextScope.value,
+                            eventId = idGenerator.generateAsString(),
                         )
                     }
                 }

--- a/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
+++ b/cosec-core/src/test/kotlin/me/ahoo/cosec/audit/AuditingAuthorizationTest.kt
@@ -45,6 +45,7 @@ import me.ahoo.cosec.principal.SimplePrincipal
 import me.ahoo.cosec.principal.SimpleTenantPrincipal
 import me.ahoo.cosec.token.TokenExpiredException
 import me.ahoo.cosec.token.TokenVerificationContexts.setTokenVerificationException
+import me.ahoo.cosid.IdGenerator
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
@@ -103,6 +104,22 @@ class AuditingAuthorizationTest {
             .verifyComplete()
         events.size.assert().isEqualTo(1)
         events[0].authorization.decision.assert().isEqualTo(AuditDecision.ALLOW)
+    }
+
+    @Test
+    fun generateEventIdWithConfiguredGenerator() {
+        val events = mutableListOf<AuditEvent>()
+        val delegate = mockk<Authorization> {
+            every { authorize(request, context) } returns AuthorizeResult.ALLOW.toMono()
+        }
+        val idGenerator = mockk<IdGenerator> {
+            every { generateAsString() } returns "event-1"
+        }
+        val authorization = AuditingAuthorization(delegate, AuditEventSink(events::add), idGenerator)
+
+        authorization.authorize(request, context).block()
+
+        events.single().eventId.assert().isEqualTo("event-1")
     }
 
     @Test

--- a/cosec-opentelemetry/src/main/kotlin/me/ahoo/cosec/opentelemetry/AuthorizationMono.kt
+++ b/cosec-opentelemetry/src/main/kotlin/me/ahoo/cosec/opentelemetry/AuthorizationMono.kt
@@ -14,6 +14,7 @@
 package me.ahoo.cosec.opentelemetry
 
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.context.Context
 import me.ahoo.cosec.api.audit.AuditTrace
 import me.ahoo.cosec.api.authorization.Authorization
@@ -37,17 +38,24 @@ class CoSecMonoTrace(
         }
         val otelContext = CoSecInstrumenter.INSTRUMENTER.start(parentContext, securityContext)
         val spanContext = Span.fromContext(otelContext).spanContext
-        val tracedRequest = request.mergeAttributes(
-            mapOf(
-                AuditTrace.TRACE_ID_ATTRIBUTE_KEY to spanContext.traceId,
-                AuditTrace.SPAN_ID_ATTRIBUTE_KEY to spanContext.spanId,
-            ),
-        )
+        val tracedRequest = request.withAuditTrace(spanContext)
         otelContext.makeCurrent().use {
             Mono.defer { delegate.authorize(tracedRequest, securityContext) }
                 .subscribe(TraceFilterSubscriber(otelContext, securityContext, actual))
         }
     }
+}
+
+internal fun Request.withAuditTrace(spanContext: SpanContext): Request {
+    if (!spanContext.isValid) {
+        return this
+    }
+    return mergeAttributes(
+        mapOf(
+            AuditTrace.TRACE_ID_ATTRIBUTE_KEY to spanContext.traceId,
+            AuditTrace.SPAN_ID_ATTRIBUTE_KEY to spanContext.spanId,
+        ),
+    )
 }
 
 class TraceFilterSubscriber(

--- a/cosec-opentelemetry/src/test/kotlin/me/ahoo/cosec/opentelemetry/TracingAuthorizationTest.kt
+++ b/cosec-opentelemetry/src/test/kotlin/me/ahoo/cosec/opentelemetry/TracingAuthorizationTest.kt
@@ -3,6 +3,7 @@ package me.ahoo.cosec.opentelemetry
 import io.mockk.every
 import io.mockk.mockk
 import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -151,6 +152,13 @@ class TracingAuthorizationTest {
 
         trace.traceId.assert().isNotBlank()
         trace.spanId.assert().isNotBlank()
+    }
+
+    @Test
+    fun invalidSpanContextDoesNotAddAuditTrace() {
+        val request = TestRequest()
+
+        request.withAuditTrace(SpanContext.getInvalid()).assert().isSameAs(request)
     }
 
     @Test

--- a/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
+++ b/cosec-spring-boot-starter/src/main/kotlin/me/ahoo/cosec/spring/boot/starter/audit/CoSecAuditAutoConfiguration.kt
@@ -19,6 +19,9 @@ import me.ahoo.cosec.audit.AuditingAuthorization
 import me.ahoo.cosec.audit.LoggingAuditEventSink
 import me.ahoo.cosec.spring.boot.starter.ConditionalOnCoSecEnabled
 import me.ahoo.cosec.spring.boot.starter.authorization.CoSecAuthorizationAutoConfiguration
+import me.ahoo.cosid.IdGenerator
+import me.ahoo.cosid.jvm.UuidGenerator
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -51,8 +54,13 @@ class CoSecAuditAutoConfiguration {
     fun cosecAuditingAuthorization(
         @Qualifier(CoSecAuthorizationAutoConfiguration.BEAN_NAME) authorization: Authorization,
         auditEventSink: AuditEventSink,
+        idGeneratorProvider: ObjectProvider<IdGenerator>,
     ): AuditingAuthorization {
-        return AuditingAuthorization(authorization, auditEventSink)
+        return AuditingAuthorization(
+            authorization,
+            auditEventSink,
+            idGeneratorProvider.getIfAvailable { UuidGenerator.INSTANCE },
+        )
     }
 
     companion object {


### PR DESCRIPTION
## Summary

- generate audit event IDs with the configured CosId `IdGenerator`, falling back to `UuidGenerator`
- omit audit trace data when OpenTelemetry returns an invalid `SpanContext`
- preserve the existing two-argument `AuditingAuthorization` JVM constructor

## Root cause

Audit event IDs were hard-coded to `UUID.randomUUID()`, bypassing the application's configured ID generator. Trace IDs were copied without checking `SpanContext.isValid`, so an incompatible or no-op OpenTelemetry provider produced all-zero trace and span IDs.

The dev deployment currently combines Java Agent `2.9.0` with OpenTelemetry API `1.64.0` / instrumentation API `2.30.0`. Updating the deployment Agent to a compatible version such as `2.30.0` remains a separate infrastructure change; this PR makes CoSec degrade safely when the context is invalid.

## Impact

Audit events use the application's cluster-safe CosId generator when available. Invalid trace contexts are omitted instead of being serialized as misleading all-zero IDs.

## Validation

- `./gradlew detekt build`
